### PR TITLE
docs: prepare repository for Evidence v0.1 stabilization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,6 @@ workspaces_verify_preflight_smoke/
 /release-run/signed_science_claim_bundle.json
 /release-run/scientific_memory_import_report.json
 /release-run/RELEASE_FIXTURE_MANIFEST.json
+
+core/cli/pf/pf
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,10 +100,9 @@ If you are forking the repo to build your own product or variant, see the [Reuse
 
 - [Getting started](docs/guides/getting-started.md)
 - [Developer guide](docs/guides/developer-guide.md)
-- [CI and supply-chain reference](docs/reference/ci-reference.md)
+- [CI and supply-chain reference](docs/reference/ci-reference.md) (workflows, local commands, artifacts not to commit)
 - [Extension points](docs/guides/extension-points.md) (adapters, bundles, runtime)
 - [Configuration reference](docs/reference/configuration.md)
-- [Agent / automation guide](AGENTS.md) (CI entry points, local commands, artifacts not to commit)
 
 ## Questions
 

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,11 @@ install-full:
 
 validate-certs:
 	@$(ECHOOK) "🔍 Validating CERT-V1 certificates..."
+	@if [ ! -f external/CERT-V1/schema/cert-v1.schema.json ]; then \
+		echo "CERT-V1 schema missing at external/CERT-V1/schema/cert-v1.schema.json"; \
+		echo "Clone per external/README.md or pass --allow-missing-schema (not recommended)."; \
+		exit 1; \
+	fi
 	python tools/cert-validate/validate.py evidence/egress_certs/*.json evidence/certs/*/*.cert.json
 	@$(ECHOOK) "✅ Certificate validation completed"
 
@@ -427,10 +432,10 @@ docs-serve:
 
 # ---------- Placeholder burn-down (P1) ----------
 # Fails if forbidden placeholder/stub patterns exist outside allowlisted paths.
-# Allowlist: docs/placeholder-burn-down-allowlist.txt
+# Allowlist: docs/internal/placeholders/placeholder-burn-down-allowlist.txt
 no-runtime-placeholders:
 	@$(ECHOOK) "Checking for forbidden placeholder/stub patterns..."
-	@python scripts/check_no_placeholder.py || (echo "no-runtime-placeholders: fix or allowlist entries (see docs/placeholder-burn-down.md)" && exit 1)
+	@python scripts/check_no_placeholder.py || (echo "no-runtime-placeholders: fix or allowlist entries (see docs/internal/placeholders/placeholder-burn-down-allowlist.txt)" && exit 1)
 
 # ---------- Convenience ----------
 logs:

--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 <div align="center">
 
+<!-- readme-banner: Provability Fabric spine (94 cols; regen: .github/assets/_build_banner.py) -->
 <pre>
-#######################################################################################
-#                                                                                     #
-#      ____                  _    _ _ _ _          _____     _          _             #
-#     |  _ \ _ __ _____   __| |__(_) (_) |_ _   _|  ___|_ _| |__  _ __(_) ___         #
-#     | |_) | '__/ _ \ \ / /| '_ \ | | | __| | | | |_ / _` | '_ \| '__| |/ __|        #
-#     |  __/| | | (_) \ V / | |_) || | | |_| |_| |  _| (_| | |_) | |  | | (__         #
-#     |_|   |_|  \___/ \_/  |_.__/_|_|_|\__|\__, |_|  \__,_|_.__/|_|  |_|\___|        #
-#                                            |___/                                    #
-#                                                                                     #
-#######################################################################################
+##############################################################################################
+#                                                                                            #
+#              ___                  _    _ _ _ _          ___     _        _                 #
+#             | _ \_ _ _____ ____ _| |__(_) (_) |_ _  _  | __|_ _| |__ _ _(_)__              #
+#             |  _/ '_/ _ \ V / _` | '_ \ | | |  _| || | | _/ _` | '_ \ '_| / _|             #
+#             |_| |_| \___/\_/\__,_|_.__/_|_|_|\__|\_, | |_|\__,_|_.__/_| |_\__|             #
+#                                                   |__/                                     #
+#                                                                                            #
+##############################################################################################
 </pre>
+
+# Provability Fabric
 
 **Formal guarantees for agent behavior** — proofs, runtime guards, and auditable evidence in one open stack.
 
 <sub>Prove · Enforce · Audit — formal specs, runtime policy, and evidence on one track.</sub>
+
+<br/>
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-site-brightgreen.svg)](https://provability-fabric.org)
@@ -23,7 +27,13 @@
 [![Lean CI](https://img.shields.io/badge/CI-Lean%20%28Morph%29-blue.svg)](.github/workflows/lean-morph.yml)
 [![PR comments](https://img.shields.io/badge/PR%20comments-enabled-blue.svg)](#)
 
-[Documentation](https://provability-fabric.org) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Agent & CI guide](AGENTS.md)
+<br/>
+
+<img src=".github/assets/provability-fabric - logofinal.png" alt="Provability Fabric" width="200"/>
+
+<br/>
+
+[Documentation](https://provability-fabric.org) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [CI reference](docs/reference/ci-reference.md)
 
 </div>
 
@@ -43,7 +53,7 @@ Provability Fabric ties **specifications and proofs** to **what actually runs**.
 
 ## Repository map
 
-The tree is large; use this as a compass. For CI, supply chain, and local commands, see [**AGENTS.md**](AGENTS.md).
+The tree is large; use this as a compass. For CI, supply chain, and local commands, see [**CONTRIBUTING.md**](CONTRIBUTING.md) and [**docs/reference/ci-reference.md**](docs/reference/ci-reference.md).
 
 | Area | Path | Notes |
 |------|------|--------|
@@ -290,7 +300,7 @@ python tests/trust_fire_orchestrator.py
 
 Report vulnerabilities per [SECURITY.md](SECURITY.md).
 
-The default branch is protected by workflows including dependency review (PRs), **cargo-deny** ([`deny.toml`](deny.toml)), **actionlint**, SBOM jobs, and OpenSSF Scorecard. Enable the [dependency graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph) where GitHub features require it. Overview: [AGENTS.md](AGENTS.md), [.github/WORKFLOWS.md](.github/WORKFLOWS.md), [docs/reference/ci-reference.md](docs/reference/ci-reference.md).
+The default branch is protected by workflows including dependency review (PRs), **cargo-deny** ([`deny.toml`](deny.toml)), **actionlint**, SBOM jobs, and OpenSSF Scorecard. Enable the [dependency graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph) where GitHub features require it. Overview: [CONTRIBUTING.md](CONTRIBUTING.md), [.github/WORKFLOWS.md](.github/WORKFLOWS.md), [docs/reference/ci-reference.md](docs/reference/ci-reference.md).
 
 ---
 

--- a/docs/evidence/overview.md
+++ b/docs/evidence/overview.md
@@ -60,4 +60,21 @@ This runs `tools/cert-validate/validate.py` against the schema at `external/CERT
 - optional `morph`: environment snapshot info when running on Morph
 - `sig`: signature for the CERT payload
 
-See also: [Standards](specs/standards.md), [Replay](replay.md), and the CERT-V1 repository for the full schema.
+See also: [Standards](specs/standards.md), [Replay](replay.md), the CERT-V1 repository for the full schema, and the [Evidence v0.1 roadmap](../roadmap/evidence-v0.1.md) for the planned bundle format and surface map.
+
+## Evidence surface map
+
+Today the repository exposes several evidence-related paths. Evidence v0.1 (in progress) adds a
+JSON bundle lane without replacing these surfaces.
+
+| Surface | Location | Role |
+|---------|----------|------|
+| Runtime CERT-V1 | `evidence/certs/<session>/<seq>.cert.json` | Sidecar-emitted certificates |
+| Sidecar log | `evidence/logs/sidecar.jsonl` | Hash-chained JSONL events |
+| TRACE-REPLAY-KIT | `tests/replay/out/certs/` (and trace outputs) | Replay-oriented CERTs and traces |
+| SWE-bench runs | `runs/<run_id>/<instance_id>/` | Run logs, metadata, replay bundles |
+| PCS science claims | `config/schemas/pcs/EvidenceBundle.v0.schema.json` | Distinct domain; not v0.1 bundles |
+| Spec archives | `so bundle pack` | tar.gz spec bundles; out of v0.1 scope |
+
+Planned v0.1 additions (`specs/evidence/v0.1/`, `pf evidence …`) are tracked in the
+[Evidence v0.1 roadmap](../roadmap/evidence-v0.1.md).

--- a/docs/internal/placeholders/placeholder-burn-down-allowlist.txt
+++ b/docs/internal/placeholders/placeholder-burn-down-allowlist.txt
@@ -1,7 +1,7 @@
 # Placeholder burn-down allowlist (P1)
 # Paths listed here may contain sanitized example placeholders (variable-style, clearly labeled).
 # Rule: variable-style (e.g. SLACK_WEBHOOK_URL, ghp_xxx), clearly labeled as example; no real-looking secrets.
-# See docs/placeholder-burn-down.md (SC-002, SC-003, BT-002, TD-015, EX-001, EX-002).
+# See docs/internal/placeholders/ (SC-002, SC-003, BT-002, TD-015, EX-001, EX-002).
 # EX-001: benign comment "Synchronous unit test stub" is skipped by script (comment-only + excuse).
 # EX-002: PostMortemStub is a type name in break_glass.rs; gate has no pattern matching it.
 # P14 proof test: test_impacted_only.py asserts script output (impacted_only --build-impacted).
@@ -16,7 +16,6 @@ tools/ci/test_impacted_only.py
 tools/pr-bot/README.md
 core/sdk/README.md
 api/v1/BUF_USAGE.md
-docs/placeholder-burn-down.md
 docs/placeholders-and-stubs.md
 docs/decisions-placeholders-v1.md
 docs/dsse-verify-contract.md

--- a/docs/reference/ci-reference.md
+++ b/docs/reference/ci-reference.md
@@ -22,7 +22,7 @@ This page summarizes GitHub Actions for this repository: the **main CI entry**, 
 | `release-sbom.yml` | On `release: published`, attaches CycloneDX JSON to the GitHub Release. |
 | `scorecards.yml` | [OpenSSF Scorecard](https://scorecard.dev/) on a schedule and on pushes to `main`. |
 
-Contributor-oriented pointers: **[AGENTS.md](https://github.com/SentinelOps-CI/provability-fabric/blob/main/AGENTS.md)** (local commands, what not to commit) and **[.github/WORKFLOWS.md](https://github.com/SentinelOps-CI/provability-fabric/blob/main/.github/WORKFLOWS.md)** (workflow inventory).
+Contributor-oriented pointers: **[CONTRIBUTING.md](https://github.com/SentinelOps-CI/provability-fabric/blob/main/CONTRIBUTING.md)** (local commands, what not to commit) and **[.github/WORKFLOWS.md](https://github.com/SentinelOps-CI/provability-fabric/blob/main/.github/WORKFLOWS.md)** (workflow inventory).
 
 ---
 

--- a/docs/roadmap/evidence-v0.1.md
+++ b/docs/roadmap/evidence-v0.1.md
@@ -1,0 +1,73 @@
+# Evidence v0.1 roadmap
+
+Evidence v0.1 delivers a minimal, reusable, validated path for packaging, validating, binding, replaying, and documenting verifiable evidence artifacts in Provability Fabric.
+
+## Definition of done
+
+- JSON Schemas under `specs/evidence/v0.1/schemas/`
+- Public specification and compatibility docs
+- Valid and invalid fixtures with pytest coverage
+- CLI namespace `pf evidence` with `bundle pack`, `validate --strict`, and `replay`
+- Runtime additive binding events without breaking CERT-V1
+- Examples, testbed scripts, CI smoke workflow, and onboarding docs
+
+## Fifteen-PR technical sequence
+
+| PR | Topic | Deliverables |
+|----|-------|--------------|
+| 1 | Hygiene | This roadmap, AGENTS link fixes, placeholder paths |
+| 2 | Schemas | Six JSON schemas + README |
+| 3 | Public spec | Model + bundle format docs |
+| 4 | Fixtures | Valid/invalid examples, compatibility matrix, schema tests |
+| 5 | Pack CLI | `core/evidence` pack + `pf evidence bundle pack` |
+| 6 | Validator | Strict validate, fail-closed cert validator |
+| 7 | E2E example | `examples/evidence-basic`, walkthrough, e2e tests |
+| 8 | Runtime binding | Sidecar `evidence_v01_binding` JSONL events |
+| 9 | Runtime boundaries | Boundaries guide |
+| 10 | Runtime scenario | `examples/runtime-evidence-basic` |
+| 11 | Replay workflow | `pf evidence replay`, `core/evidence/replay.go` |
+| 12 | Replay docs | Replay guarantees guide |
+| 13 | Forensic example | Pass/tamper forensic walkthrough |
+| 14 | Testbed | `testbed/evidence-v0.1` scripts + CI smoke |
+| 15 | Onboarding | Quickstart, status doc, CHANGELOG, mkdocs nav |
+
+## Current platform map
+
+| Surface | Role relative to v0.1 |
+|---------|------------------------|
+| CERT-V1 sidecar certs | Compatible attestation artifact type (external schema) |
+| TRACE-REPLAY-KIT (`so trace …`) | Execution trace input; not replaced by v0.1 replay |
+| PCS `EvidenceBundle.v0` | Related science-claim domain; documented separately |
+| `so bundle pack` | Spec tar archives; out of scope for v0.1 JSON bundles |
+
+## Known limitations (honest)
+
+- `pf check-trace` only verifies that `bundles/` exists; it is not a traceability validator.
+- `replayStatusCmdNew()` exists but is not registered; `replay status` uses the legacy handler.
+- `tools/cert-validate/validate.py` previously exited 0 when the external CERT-V1 schema was missing; strict mode now fails closed unless `--allow-missing-schema` is passed.
+- Windows: some replay integration tests may skip when bash or external clones are unavailable.
+
+## VERSION vs tags
+
+Root [`VERSION`](../../VERSION) tracks the next platform release marker. Git tags (for example `v1.9.2`) reflect historical releases. Do not assume they match without checking release notes.
+
+## Pre-PR 0 baseline results
+
+Recorded on Windows checkout at `65bee159035e38e7a8f907ce2773226eca1ea4f3` (clean `main`):
+
+| Command | Result | Notes |
+|---------|--------|-------|
+| `go test ./...` (`core/cli/pf`) | Fail | Pre-existing `pf/cmd` PCS test failures |
+| `go build -o pf .` (`core/cli/pf`) | Pass | |
+| `cargo test --workspace --exclude sidecar-watcher` | Fail | `labeler` stress tests |
+| `cargo test -p sidecar-watcher` | Fail | Windows linker `LNK1104` contention |
+| `python tools/cert-validate/validate.py --help` | Pass | |
+| `mkdocs build` | Pass | Pre-existing unrelated link warnings |
+| `make validate-certs` | Pass (vacuous) | Schema missing before fail-closed fix |
+| `make no-runtime-placeholders` | Fail | Scans `build/` after mkdocs |
+
+`external/CERT-V1/` is absent unless cloned per [`external/README.md`](../../external/README.md).
+
+## Status
+
+See [Evidence v0.1 status](evidence-v0.1-status.md) for the completion checklist.

--- a/docs/security/overview.md
+++ b/docs/security/overview.md
@@ -94,7 +94,7 @@ Provability Fabric is a zero-trust, enclave-based system that provides cryptogra
 - **Network Security**: Firewalls, IDS/IPS, DDoS protection
 - **Code Security**: Static analysis, dynamic testing, code reviews
 - **Access Control**: Multi-factor authentication, least privilege
-- **Supply Chain**: Dependency scanning (GitHub **Dependency review** on PRs, **cargo-deny** with root `deny.toml`, SBOM diff / Grype in CI), signed releases where applicable, and workflow linting (**actionlint**) when `.github/workflows/**` changes. See [CI reference](../reference/ci-reference.md), [SECURITY.md](https://github.com/SentinelOps-CI/provability-fabric/blob/main/SECURITY.md), and [AGENTS.md](https://github.com/SentinelOps-CI/provability-fabric/blob/main/AGENTS.md).
+- **Supply Chain**: Dependency scanning (GitHub **Dependency review** on PRs, **cargo-deny** with root `deny.toml`, SBOM diff / Grype in CI), signed releases where applicable, and workflow linting (**actionlint**) when `.github/workflows/**` changes. See [CI reference](../reference/ci-reference.md), [SECURITY.md](https://github.com/SentinelOps-CI/provability-fabric/blob/main/SECURITY.md), and [CONTRIBUTING.md](https://github.com/SentinelOps-CI/provability-fabric/blob/main/CONTRIBUTING.md).
 - **Physical Security**: Secure facilities, hardware security modules
 
 ## Compliance & Auditing

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,8 @@ nav:
   - Evidence:
       - Overview: evidence/overview.md
       - Replay: evidence/replay.md
+  - Roadmap:
+      - Evidence v0.1: roadmap/evidence-v0.1.md
   - Security:
       - Overview: security/overview.md
       - Threat model: security/threat_model.md

--- a/scripts/check_no_placeholder.py
+++ b/scripts/check_no_placeholder.py
@@ -3,7 +3,7 @@
 # Copyright 2025 Provability-Fabric Contributors
 #
 # P1 gate: scan repo for forbidden placeholder/stub patterns.
-# Allowlisted paths (docs/placeholder-burn-down-allowlist.txt) are skipped.
+# Allowlisted paths (docs/internal/placeholders/placeholder-burn-down-allowlist.txt) are skipped.
 # Exit 0 if no forbidden patterns; 1 otherwise.
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
This PR advances the Evidence v0.1 path by establishing repository hygiene: roadmap, contributor pointers, placeholder allowlist updates, and removal of a committed `pf` binary so the stack can land cleanly.

## Scope
- Add `docs/roadmap/evidence-v0.1.md` with the 15-PR sequence and known limitations
- Update `README.md`, `CONTRIBUTING.md`, `docs/evidence/overview.md`, and `mkdocs.yml` for Evidence v0.1 navigation
- Extend `.gitignore` and remove tracked `core/cli/pf/pf` binary artifact
- Align placeholder-burn-down allowlist and `scripts/check_no_placeholder.py` paths

## Out of scope
- JSON schemas, CLI commands, runtime binding, replay workflow, and testbed scripts (later PRs)

## Acceptance criteria
- [ ] Public artifact added or updated
- [ ] Tests or fixtures included
- [ ] Documentation updated
- [ ] Reproducible command included
- [ ] Known limitations documented

## Verification
```bash
mkdocs build
grep -n AGENTS.md README.md CONTRIBUTING.md
grep -n placeholder-burn-down docs/
```

## Notes for reviewers
Please focus review on: schema stability, validation behavior, artifact compatibility, reproducibility, failure modes.