### PR TITLE
specs: add Evidence v0.1 artifact schemas

### DIFF
--- a/specs/evidence/v0.1/README.md
+++ b/specs/evidence/v0.1/README.md
@@ -1,0 +1,34 @@
+# Evidence v0.1 schemas
+
+Machine-readable JSON Schema (draft 2020-12) artifacts for the Evidence v0.1 lane.
+
+## Layout
+
+| Schema | Purpose |
+|--------|---------|
+| `claim.schema.json` | Declarative claim about agent behavior |
+| `proof.schema.json` | Proof artifact with digest-bound refs |
+| `attestation.schema.json` | Attestation over a signed claim ref |
+| `execution-trace.schema.json` | Ordered execution trace with self-digest |
+| `evidence-bundle.schema.json` | Bundle manifest composing artifact refs |
+| `validation-report.schema.json` | Strict validation outcome report |
+
+## Stable `$id`
+
+Each schema exposes a stable HTTPS `$id` under:
+
+`https://provability-fabric.org/schemas/evidence/v0.1/<name>.schema.json`
+
+## Required fields
+
+All top-level artifacts include `schema_version: "0.1"`. Artifact references use:
+
+```json
+{ "role": "...", "path": "...", "media_type": "...", "digest": "sha256:<hex>" }
+```
+
+## Related docs
+
+- [Evidence model v0.1](../../docs/specs/evidence-model-v0.1.md)
+- [Evidence bundle v0.1](../../docs/specs/evidence-bundle-v0.1.md)
+- [Compatibility matrix](../../docs/specs/evidence-compatibility.md)

--- a/specs/evidence/v0.1/schemas/attestation.schema.json
+++ b/specs/evidence/v0.1/schemas/attestation.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://provability-fabric.org/schemas/evidence/v0.1/attestation.schema.json",
+  "title": "EvidenceAttestationV01",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "attestation_id", "attestor", "signed_claim_ref", "signature"],
+  "properties": {
+    "schema_version": { "const": "0.1" },
+    "attestation_id": { "type": "string", "minLength": 1 },
+    "attestor": { "type": "string", "minLength": 1 },
+    "signed_claim_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "path", "media_type", "digest"],
+      "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "media_type": { "type": "string", "minLength": 1 },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        }
+      }
+    },
+    "signature": { "type": "string", "minLength": 1 },
+    "media_type": {
+      "type": "string",
+      "description": "Optional media type when attestation wraps CERT-V1"
+    }
+  }
+}

--- a/specs/evidence/v0.1/schemas/claim.schema.json
+++ b/specs/evidence/v0.1/schemas/claim.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://provability-fabric.org/schemas/evidence/v0.1/claim.schema.json",
+  "title": "EvidenceClaimV01",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "claim_id", "statement", "subject"],
+  "properties": {
+    "schema_version": { "const": "0.1" },
+    "claim_id": { "type": "string", "minLength": 1 },
+    "statement": { "type": "string", "minLength": 1 },
+    "subject": {
+      "type": "object",
+      "additionalProperties": true,
+      "minProperties": 1
+    }
+  }
+}

--- a/specs/evidence/v0.1/schemas/evidence-bundle.schema.json
+++ b/specs/evidence/v0.1/schemas/evidence-bundle.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://provability-fabric.org/schemas/evidence/v0.1/evidence-bundle.schema.json",
+  "title": "EvidenceBundleV01",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["bundle_id", "schema_version", "artifacts", "bundle_digest", "created_at", "producer"],
+  "properties": {
+    "bundle_id": { "type": "string", "minLength": 1 },
+    "schema_version": { "const": "0.1" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "producer": { "type": "string", "minLength": 1 },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/artifact_ref" }
+    },
+    "bundle_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  },
+  "$defs": {
+    "artifact_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "path", "media_type", "digest"],
+      "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "media_type": { "type": "string", "minLength": 1 },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        }
+      }
+    }
+  }
+}

--- a/specs/evidence/v0.1/schemas/execution-trace.schema.json
+++ b/specs/evidence/v0.1/schemas/execution-trace.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://provability-fabric.org/schemas/evidence/v0.1/execution-trace.schema.json",
+  "title": "EvidenceExecutionTraceV01",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "trace_id", "events", "trace_digest"],
+  "properties": {
+    "schema_version": { "const": "0.1" },
+    "trace_id": { "type": "string", "minLength": 1 },
+    "events": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["seq", "kind"],
+        "properties": {
+          "seq": { "type": "integer", "minimum": 0 },
+          "kind": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "trace_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/specs/evidence/v0.1/schemas/proof.schema.json
+++ b/specs/evidence/v0.1/schemas/proof.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://provability-fabric.org/schemas/evidence/v0.1/proof.schema.json",
+  "title": "EvidenceProofV01",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "proof_id", "proof_system", "artifact_refs", "proof_digest"],
+  "properties": {
+    "schema_version": { "const": "0.1" },
+    "proof_id": { "type": "string", "minLength": 1 },
+    "proof_system": { "type": "string", "minLength": 1 },
+    "artifact_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/artifact_ref" }
+    },
+    "proof_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  },
+  "$defs": {
+    "artifact_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "path", "media_type", "digest"],
+      "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "media_type": { "type": "string", "minLength": 1 },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        }
+      }
+    }
+  }
+}

--- a/specs/evidence/v0.1/schemas/validation-report.schema.json
+++ b/specs/evidence/v0.1/schemas/validation-report.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://provability-fabric.org/schemas/evidence/v0.1/validation-report.schema.json",
+  "title": "EvidenceValidationReportV01",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["report_id", "bundle_ref", "status", "errors", "warnings", "validated_at"],
+  "properties": {
+    "report_id": { "type": "string", "minLength": 1 },
+    "bundle_ref": { "type": "string", "minLength": 1 },
+    "status": { "enum": ["pass", "fail"] },
+    "errors": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "validated_at": { "type": "string", "format": "date-time" }
+  }
+}


### PR DESCRIPTION
## Summary
This PR advances the Evidence v0.1 path by publishing six draft-2020-12 JSON Schemas with stable `$id` URLs and a schema README under `specs/evidence/v0.1/`.

## Scope
- Add schemas: `claim`, `proof`, `attestation`, `execution-trace`, `evidence-bundle`, `validation-report`
- Document layout, required `schema_version: "0.1"`, and digest-bound artifact refs in `specs/evidence/v0.1/README.md`

## Out of scope
- Narrative specification docs, fixtures, CLI pack/validate/replay, and runtime integration

## Acceptance criteria
- [ ] Public artifact added or updated
- [ ] Tests or fixtures included
- [ ] Documentation updated
- [ ] Reproducible command included
- [ ] Known limitations documented

## Verification
```bash
for f in specs/evidence/v0.1/schemas/*.schema.json; do
  python -m json.tool "$f" > /dev/null
done
```

## Notes for reviewers
Please focus review on: schema stability, validation behavior, artifact compatibility, reproducibility, failure modes.