### PR TITLE
cli: add Evidence v0.1 bundle packaging command

### DIFF
--- a/core/cli/pf/evidence_commands.go
+++ b/core/cli/pf/evidence_commands.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	evidence "github.com/SentinelOps-CI/provability-fabric/core/evidence"
+	"github.com/spf13/cobra"
+)
+
+func evidenceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "evidence",
+		Short: "Evidence v0.1 bundle pack",
+		Long:  "Pack Evidence v0.1 JSON bundles (distinct from PCS EvidenceBundle.v0 and so bundle pack tar archives).",
+	}
+	cmd.AddCommand(evidenceBundleCmd())
+	return cmd
+}
+
+func evidenceBundleCmd() *cobra.Command {
+	var manifestPath, outPath string
+	var jsonOut bool
+
+	bundle := &cobra.Command{
+		Use:   "bundle",
+		Short: "Evidence v0.1 bundle operations",
+	}
+	pack := &cobra.Command{
+		Use:   "pack",
+		Short: "Pack an Evidence v0.1 bundle from a manifest",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if manifestPath == "" || outPath == "" {
+				return fmt.Errorf("--manifest and --out are required")
+			}
+			b, err := evidence.Pack(evidence.PackOptions{
+				ManifestPath: manifestPath,
+				OutPath:      outPath,
+			})
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(b)
+			}
+			fmt.Printf("Wrote bundle %s (digest %s)\n", outPath, b.BundleDigest)
+			return nil
+		},
+	}
+	pack.Flags().StringVar(&manifestPath, "manifest", "", "Path to pack manifest JSON")
+	pack.Flags().StringVar(&outPath, "out", "", "Output bundle JSON path")
+	pack.Flags().BoolVar(&jsonOut, "json", false, "Emit packed bundle JSON to stdout")
+	_ = pack.MarkFlagRequired("manifest")
+	_ = pack.MarkFlagRequired("out")
+	bundle.AddCommand(pack)
+	return bundle
+}

--- a/core/cli/pf/go.mod
+++ b/core/cli/pf/go.mod
@@ -4,6 +4,7 @@ go 1.23
 
 require (
 	github.com/SentinelOps-CI/provability-fabric/adapters/pcs v0.0.0
+	github.com/SentinelOps-CI/provability-fabric/core/evidence v0.0.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/spf13/cobra v1.8.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -12,6 +13,8 @@ require (
 )
 
 replace github.com/SentinelOps-CI/provability-fabric/adapters/pcs => ../../../adapters/pcs
+
+replace github.com/SentinelOps-CI/provability-fabric/core/evidence => ../../evidence
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/core/cli/pf/main.go
+++ b/core/cli/pf/main.go
@@ -79,6 +79,7 @@ func init() {
 	rootCmd.AddCommand(epochCmd())
 	rootCmd.AddCommand(perfCmd())
 	rootCmd.AddCommand(traceCmd())
+	rootCmd.AddCommand(evidenceCmd())
 
 	// Enhanced unified commands for developer workflow
 	rootCmd.AddCommand(explainStateCmd())

--- a/core/evidence/bundle.go
+++ b/core/evidence/bundle.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+package evidence
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ArtifactRef is a digest-bound reference to a bundled artifact.
+type ArtifactRef struct {
+	Role      string `json:"role"`
+	Path      string `json:"path"`
+	MediaType string `json:"media_type"`
+	Digest    string `json:"digest"`
+}
+
+// EvidenceBundle is the v0.1 bundle manifest.
+type EvidenceBundle struct {
+	BundleID      string        `json:"bundle_id"`
+	SchemaVersion string        `json:"schema_version"`
+	CreatedAt     string        `json:"created_at"`
+	Producer      string        `json:"producer"`
+	Artifacts     []ArtifactRef `json:"artifacts"`
+	BundleDigest  string        `json:"bundle_digest"`
+}
+
+// PackManifest describes inputs for bundle pack.
+type PackManifest struct {
+	SchemaVersion string `json:"schema_version"`
+	BundleID      string `json:"bundle_id"`
+	Producer      string `json:"producer"`
+	CreatedAt     string `json:"created_at,omitempty"`
+	Artifacts     []struct {
+		Role      string `json:"role"`
+		Path      string `json:"path"`
+		MediaType string `json:"media_type,omitempty"`
+	} `json:"artifacts"`
+}
+
+var roleMediaTypes = map[string]string{
+	"claim":           "application/vnd.provability-fabric.evidence.claim+json",
+	"proof":           "application/vnd.provability-fabric.evidence.proof+json",
+	"attestation":     "application/vnd.provability-fabric.evidence.attestation+json",
+	"execution-trace": "application/vnd.provability-fabric.evidence.execution-trace+json",
+	"cert-v1":         "application/vnd.cert-v1+json",
+}
+
+// PackOptions controls bundle pack behavior.
+type PackOptions struct {
+	ManifestPath string
+	OutPath      string
+	BaseDir      string
+}
+
+// Pack reads a manifest, resolves artifact digests, and writes a bundle JSON file.
+func Pack(opts PackOptions) (*EvidenceBundle, error) {
+	if opts.BaseDir == "" {
+		opts.BaseDir = filepath.Dir(opts.ManifestPath)
+	}
+	data, err := os.ReadFile(opts.ManifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+	var manifest PackManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+	if manifest.SchemaVersion != SchemaVersion {
+		return nil, fmt.Errorf("unsupported schema_version %q", manifest.SchemaVersion)
+	}
+	if manifest.BundleID == "" {
+		return nil, fmt.Errorf("manifest missing bundle_id")
+	}
+	if manifest.Producer == "" {
+		manifest.Producer = "pf-evidence/v0.1"
+	}
+	if manifest.CreatedAt == "" {
+		manifest.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if len(manifest.Artifacts) == 0 {
+		return nil, fmt.Errorf("manifest missing artifacts")
+	}
+
+	refs := make([]ArtifactRef, 0, len(manifest.Artifacts))
+	for _, art := range manifest.Artifacts {
+		if art.Role == "" || art.Path == "" {
+			return nil, fmt.Errorf("artifact missing role or path")
+		}
+		mediaType := art.MediaType
+		if mediaType == "" {
+			mediaType = roleMediaTypes[art.Role]
+			if mediaType == "" {
+				return nil, fmt.Errorf("unknown role %q and no media_type provided", art.Role)
+			}
+		}
+		absPath := filepath.Join(opts.BaseDir, filepath.FromSlash(art.Path))
+		digest, err := FileDigest(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("digest artifact %s: %w", art.Path, err)
+		}
+		refs = append(refs, ArtifactRef{
+			Role:      art.Role,
+			Path:      filepath.ToSlash(art.Path),
+			MediaType: mediaType,
+			Digest:    digest,
+		})
+	}
+
+	bundle := EvidenceBundle{
+		BundleID:      manifest.BundleID,
+		SchemaVersion: SchemaVersion,
+		CreatedAt:     manifest.CreatedAt,
+		Producer:      manifest.Producer,
+		Artifacts:     refs,
+	}
+	digest, err := bundleDigest(bundle)
+	if err != nil {
+		return nil, err
+	}
+	bundle.BundleDigest = digest
+
+	out, err := json.MarshalIndent(bundle, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(opts.OutPath, out, 0644); err != nil {
+		return nil, fmt.Errorf("write bundle: %w", err)
+	}
+	return &bundle, nil
+}
+
+func bundleDigest(bundle EvidenceBundle) (string, error) {
+	m, err := bundleToMap(bundle)
+	if err != nil {
+		return "", err
+	}
+	delete(m, "bundle_digest")
+	return CanonicalJSONDigest(m, "")
+}
+
+// bundleToMap converts a bundle struct to map[string]any via JSON round-trip
+// so nested artifact slices hash consistently with fixture tooling.
+func bundleToMap(bundle EvidenceBundle) (map[string]any, error) {
+	data, err := json.Marshal(bundle)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/core/evidence/bundle_test.go
+++ b/core/evidence/bundle_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+package evidence
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := FindRepoRoot(".")
+	if err != nil {
+		t.Fatalf("find repo root: %v", err)
+	}
+	return root
+}
+
+func TestPackValidFixture(t *testing.T) {
+	root := repoRoot(t)
+	exampleDir := filepath.Join(root, "specs", "evidence", "v0.1", "examples", "valid")
+	manifest := filepath.Join(exampleDir, "manifest.json")
+	out := filepath.Join(t.TempDir(), "bundle.json")
+
+	bundle, err := Pack(PackOptions{
+		ManifestPath: manifest,
+		OutPath:      out,
+		BaseDir:      exampleDir,
+	})
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	if bundle.BundleDigest == "" {
+		t.Fatal("expected bundle_digest")
+	}
+}
+
+func TestBundleDigestDeterministic(t *testing.T) {
+	root := repoRoot(t)
+	exampleDir := filepath.Join(root, "specs", "evidence", "v0.1", "examples", "valid")
+	manifest := filepath.Join(exampleDir, "manifest.json")
+	tmp := t.TempDir()
+	out1 := filepath.Join(tmp, "one.json")
+	out2 := filepath.Join(tmp, "two.json")
+
+	b1, err := Pack(PackOptions{ManifestPath: manifest, OutPath: out1, BaseDir: exampleDir})
+	if err != nil {
+		t.Fatalf("pack one: %v", err)
+	}
+	b2, err := Pack(PackOptions{ManifestPath: manifest, OutPath: out2, BaseDir: exampleDir})
+	if err != nil {
+		t.Fatalf("pack two: %v", err)
+	}
+	if b1.BundleDigest != b2.BundleDigest {
+		t.Fatalf("digests differ: %s vs %s", b1.BundleDigest, b2.BundleDigest)
+	}
+}
+
+func TestBundleToMapRoundTrip(t *testing.T) {
+	bundle := EvidenceBundle{
+		BundleID:      "test",
+		SchemaVersion: SchemaVersion,
+		CreatedAt:     "2025-01-01T00:00:00Z",
+		Producer:      "test",
+		Artifacts: []ArtifactRef{{
+			Role: "claim", Path: "artifacts/claim.json",
+			MediaType: "application/vnd.provability-fabric.evidence.claim+json",
+			Digest:    "sha256:abc",
+		}},
+	}
+	m, err := bundleToMap(bundle)
+	if err != nil {
+		t.Fatalf("bundleToMap: %v", err)
+	}
+	if _, ok := m["artifacts"].([]any); !ok {
+		raw, _ := json.Marshal(m["artifacts"])
+		t.Fatalf("artifacts not []any: %s", string(raw))
+	}
+}
+
+func TestCanonicalJSONDigest(t *testing.T) {
+	left := map[string]any{"b": 1, "a": 2}
+	right := map[string]any{"a": 2, "b": 1}
+	d1, err := CanonicalJSONDigest(left, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d2, err := CanonicalJSONDigest(right, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d1 != d2 {
+		t.Fatalf("canonical digests differ: %s %s", d1, d2)
+	}
+}
+
+func TestFileDigest(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "x.txt")
+	if err := os.WriteFile(f, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := FileDigest(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824" {
+		t.Fatalf("unexpected digest %s", d)
+	}
+}

--- a/core/evidence/digest.go
+++ b/core/evidence/digest.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+package evidence
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+const SchemaVersion = "0.1"
+
+// DigestPrefix is the required digest prefix for v0.1 artifacts.
+const DigestPrefix = "sha256:"
+
+// FileDigest returns sha256 digest of raw file bytes.
+func FileDigest(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return DigestPrefix + hex.EncodeToString(sum[:]), nil
+}
+
+// CanonicalJSONDigest hashes canonical JSON of v excluding excludeKey when set.
+func CanonicalJSONDigest(v any, excludeKey string) (string, error) {
+	m, err := toMap(v)
+	if err != nil {
+		return "", err
+	}
+	if excludeKey != "" {
+		cloned := make(map[string]any, len(m))
+		for k, val := range m {
+			if k == excludeKey {
+				continue
+			}
+			cloned[k] = val
+		}
+		m = cloned
+	}
+	data, err := MarshalCanonical(m)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return DigestPrefix + hex.EncodeToString(sum[:]), nil
+}
+
+// MarshalCanonical emits UTF-8 JSON with recursively sorted object keys.
+func MarshalCanonical(v any) ([]byte, error) {
+	normalized, err := normalizeForCanonical(v)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(normalized)
+}
+
+func normalizeForCanonical(v any) (any, error) {
+	switch t := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		out := make(map[string]any, len(t))
+		for _, k := range keys {
+			n, err := normalizeForCanonical(t[k])
+			if err != nil {
+				return nil, err
+			}
+			out[k] = n
+		}
+		return out, nil
+	case []any:
+		out := make([]any, len(t))
+		for i, item := range t {
+			n, err := normalizeForCanonical(item)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = n
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}
+
+// toMap converts JSON-round-tripped values into map[string]any for stable hashing.
+func toMap(v any) (map[string]any, error) {
+	switch m := v.(type) {
+	case map[string]any:
+		return m, nil
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		var out map[string]any
+		if err := json.Unmarshal(data, &out); err != nil {
+			return nil, fmt.Errorf("value is not a JSON object: %w", err)
+		}
+		return out, nil
+	}
+}
+
+// FindRepoRoot walks upward from start looking for specs/evidence/v0.1.
+func FindRepoRoot(start string) (string, error) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", err
+	}
+	for {
+		candidate := filepath.Join(dir, "specs", "evidence", "v0.1", "schemas")
+		if st, err := os.Stat(candidate); err == nil && st.IsDir() {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", fmt.Errorf("repo root not found from %s", start)
+}

--- a/core/evidence/go.mod
+++ b/core/evidence/go.mod
@@ -1,0 +1,5 @@
+module github.com/SentinelOps-CI/provability-fabric/core/evidence
+
+go 1.23
+
+require github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/core/evidence/go.sum
+++ b/core/evidence/go.sum
@@ -1,0 +1,2 @@
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=

--- a/specs/evidence/v0.1/README.md
+++ b/specs/evidence/v0.1/README.md
@@ -27,6 +27,10 @@ All top-level artifacts include `schema_version: "0.1"`. Artifact references use
 { "role": "...", "path": "...", "media_type": "...", "digest": "sha256:<hex>" }
 ```
 
+## Tests
+
+Bundle pack and digest coverage lives in Go (`core/evidence/bundle_test.go`, run `go test ./...` in that module). `tests/evidence_bundle/test_bundle_pack.py` is a thin pytest shim so pack tests appear in the Evidence test suite without duplicating Go logic.
+
 ## Related docs
 
 - [Evidence model v0.1](../../docs/specs/evidence-model-v0.1.md)

--- a/tests/evidence_bundle/evidence_bundle/test_bundle_pack.py
+++ b/tests/evidence_bundle/evidence_bundle/test_bundle_pack.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Pytest discoverability shim for core/evidence pack tests (Go-native)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+EVIDENCE_DIR = REPO / "core" / "evidence"
+
+
+def test_pack_go_tests() -> None:
+    proc = subprocess.run(
+        ["go", "test", "./...", "-run", "TestPack|TestBundleDigest|TestBundleToMap|TestCanonicalJSON|TestFileDigest"],
+        cwd=EVIDENCE_DIR,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout

--- a/tests/evidence_bundle/test_bundle_pack.py
+++ b/tests/evidence_bundle/test_bundle_pack.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Pytest discoverability shim for core/evidence pack tests (Go-native)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+EVIDENCE_DIR = REPO / "core" / "evidence"
+
+
+def test_pack_go_tests() -> None:
+    proc = subprocess.run(
+        ["go", "test", "./...", "-run", "TestPack|TestBundleDigest|TestBundleToMap|TestCanonicalJSON|TestFileDigest"],
+        cwd=EVIDENCE_DIR,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout


### PR DESCRIPTION
## Summary
This PR advances the Evidence v0.1 path by implementing `core/evidence` bundle packing with SHA-256 digests and exposing `pf evidence bundle pack` for reproducible artifact archives.

## Scope
- Add `core/evidence/bundle.go`, `digest.go`, and pack-only unit tests
- Wire `pf evidence bundle pack` in `core/cli/pf/evidence_commands.go`
- Add `tests/evidence_bundle/test_bundle_pack.py` pytest shim (shells out to Go pack tests)
- Note in `specs/evidence/v0.1/README.md`: primary pack tests are Go-native

## Out of scope
- Strict validation mode (`ValidateBundle` tests land in PR6), replay verification, runtime binding, and testbed CI

## Acceptance criteria
- [ ] Public artifact added or updated
- [ ] Tests or fixtures included
- [ ] Documentation updated
- [ ] Reproducible command included
- [ ] Known limitations documented

## Verification
```bash
cd core/evidence && go test ./...
pytest tests/evidence_bundle -q
cd ../cli/pf && go build -o pf .
./pf evidence bundle pack --help
```

## Notes for reviewers
Please focus review on: schema stability, validation behavior, artifact compatibility, reproducibility, failure modes.