### PR TITLE
runtime: bind execution events to Evidence v0.1 artifacts

### DIFF
--- a/docs/guides/runtime-evidence-basic.md
+++ b/docs/guides/runtime-evidence-basic.md
@@ -2,6 +2,10 @@
 
 Sidecar-watcher emits CERT-V1 certificates and may append additive Evidence v0.1 binding records.
 
+## Emit path (v0.1)
+
+Binding events are written from the **permit enforcement** emit path only (`permit_enforcement.rs` → `write_cert_with_binding`). Other sidecar code paths do not emit Evidence v0.1 bindings in v0.1.
+
 ## Binding event
 
 `write_cert_with_binding` writes the CERT as today, then appends a JSONL line shaped like:
@@ -26,6 +30,19 @@ Implementation: [`runtime/sidecar-watcher/src/evidence_v01.rs`](../../runtime/si
 ```bash
 pf evidence validate examples/runtime-evidence-basic/basic-evidence-bundle.json --strict
 ```
+
+Run the static or live scenario:
+
+```bash
+bash examples/runtime-evidence-basic/run_scenario.sh
+bash examples/runtime-evidence-basic/run_scenario.sh --live   # requires external/CERT-V1
+```
+
+## CI requirements (live test)
+
+- Linux runner (`ubuntu-latest`)
+- `external/CERT-V1` submodule present (`make submodules`)
+- `tests/runtime_evidence/test_runtime_evidence_sidecar.py` gates on both; skipped on Windows local runs
 
 ## Related
 

--- a/docs/guides/runtime-evidence-basic.md
+++ b/docs/guides/runtime-evidence-basic.md
@@ -1,0 +1,33 @@
+# Runtime evidence basic
+
+Sidecar-watcher emits CERT-V1 certificates and may append additive Evidence v0.1 binding records.
+
+## Binding event
+
+`write_cert_with_binding` writes the CERT as today, then appends a JSONL line shaped like:
+
+```json
+{
+  "event_type": "evidence_v01_binding",
+  "session_id": "runtime-demo-001",
+  "cert_path": "evidence/certs/runtime-demo-001/1.cert.json",
+  "evidence_bundle_ref": "examples/runtime-evidence-basic/basic-evidence-bundle.json",
+  "artifact_digests": { "cert-v1": "sha256:..." },
+  "schema_version": "0.1"
+}
+```
+
+Implementation: [`runtime/sidecar-watcher/src/evidence_v01.rs`](../../runtime/sidecar-watcher/src/evidence_v01.rs).
+
+## Example bundle
+
+`examples/runtime-evidence-basic/basic-evidence-bundle.json` validates with:
+
+```bash
+pf evidence validate examples/runtime-evidence-basic/basic-evidence-bundle.json --strict
+```
+
+## Related
+
+- [Runtime evidence boundaries](runtime-evidence-boundaries.md)
+- [Evidence overview](../evidence/overview.md)

--- a/runtime/sidecar-watcher/src/cert_v1.rs
+++ b/runtime/sidecar-watcher/src/cert_v1.rs
@@ -80,3 +80,27 @@ pub fn write_cert(cert: &CertV1, session: &str, seq: u64) -> Result<String> {
 
     Ok(path)
 }
+
+/// Write CERT and optional Evidence v0.1 binding (additive JSONL event).
+pub fn write_cert_with_binding(cert: &CertV1, session: &str, seq: u64, bundle_ref: Option<&str>) -> Result<String> {
+    let path = write_cert(cert, session, seq)?;
+    let mut binding = crate::evidence_v01::EvidenceV01Binding::new(session, &path);
+    if let Some(ref_id) = bundle_ref {
+        binding = binding.with_bundle_ref(ref_id);
+    }
+    if let Ok(digest) = digest_cert_file(&path) {
+        binding = binding.with_artifact_digest("cert-v1", digest);
+    }
+    crate::evidence_v01::write_evidence_binding(&binding)?;
+    Ok(path)
+}
+
+fn digest_cert_file(path: &str) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    let sum = Sha256::digest(&buf);
+    Ok(format!("sha256:{:x}", sum))
+}

--- a/runtime/sidecar-watcher/src/cert_v1.rs
+++ b/runtime/sidecar-watcher/src/cert_v1.rs
@@ -104,3 +104,68 @@ fn digest_cert_file(path: &str) -> Result<String> {
     let sum = Sha256::digest(&buf);
     Ok(format!("sha256:{:x}", sum))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::{BufRead, BufReader};
+    use std::path::{Path, PathBuf};
+
+    fn cert_schema_available() -> bool {
+        Path::new("external/CERT-V1/schema/cert-v1.schema.json").exists()
+    }
+
+    fn sample_cert() -> CertV1 {
+        CertV1 {
+            bundle_id: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            policy_hash: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+            proof_hash: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc".to_string(),
+            automata_hash: "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_string(),
+            labeler_hash: "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_string(),
+            ni_monitor: "accept".to_string(),
+            permit_decision: "accept".to_string(),
+            path_witness_ok: true,
+            label_derivation_ok: true,
+            epoch: 1,
+            sidecar_build: "test@1.0".to_string(),
+            egress_profile: "EGRESS-DET-P1@1.0".to_string(),
+            morph: None,
+            sig: "unconfigured".to_string(),
+        }
+    }
+
+    #[test]
+    fn write_cert_with_binding_emits_binding_jsonl() {
+        if !cert_schema_available() {
+            eprintln!("skip: CERT-V1 schema missing");
+            return;
+        }
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        std::env::set_current_dir(tmp.path()).expect("chdir");
+
+        let cert = sample_cert();
+        let bundle_ref = "examples/runtime-evidence-basic/basic-evidence-bundle.json";
+        let path = write_cert_with_binding(&cert, "runtime-demo-001", 1, Some(bundle_ref))
+            .expect("write cert with binding");
+        assert!(Path::new(&path).is_file(), "cert file written");
+
+        let log_path = PathBuf::from("evidence/logs/sidecar.jsonl");
+        assert!(log_path.is_file(), "expected sidecar.jsonl");
+
+        let file = fs::File::open(&log_path).expect("open log");
+        let lines: Vec<String> = BufReader::new(file)
+            .lines()
+            .map(|l| l.expect("read line"))
+            .collect();
+        assert!(lines.len() >= 2, "expected cert line and binding line");
+
+        let binding_line = lines.last().expect("binding line");
+        let parsed: crate::evidence_v01::EvidenceV01Binding =
+            serde_json::from_str(binding_line).expect("binding JSONL");
+        assert_eq!(parsed.event_type, "evidence_v01_binding");
+        assert_eq!(parsed.evidence_bundle_ref.as_deref(), Some(bundle_ref));
+        assert!(parsed.artifact_digests.contains_key("cert-v1"));
+    }
+}

--- a/runtime/sidecar-watcher/src/evidence_v01.rs
+++ b/runtime/sidecar-watcher/src/evidence_v01.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs::{create_dir_all, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvidenceV01Binding {
+    pub event_type: String,
+    pub session_id: String,
+    pub cert_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_bundle_ref: Option<String>,
+    pub artifact_digests: BTreeMap<String, String>,
+    pub schema_version: String,
+}
+
+impl EvidenceV01Binding {
+    pub fn new(session_id: &str, cert_path: &str) -> Self {
+        Self {
+            event_type: "evidence_v01_binding".to_string(),
+            session_id: session_id.to_string(),
+            cert_path: cert_path.to_string(),
+            evidence_bundle_ref: None,
+            artifact_digests: BTreeMap::new(),
+            schema_version: "0.1".to_string(),
+        }
+    }
+
+    pub fn with_bundle_ref(mut self, bundle_ref: &str) -> Self {
+        self.evidence_bundle_ref = Some(bundle_ref.to_string());
+        self
+    }
+
+    pub fn with_artifact_digest(mut self, role: &str, digest: String) -> Self {
+        self.artifact_digests.insert(role.to_string(), digest);
+        self
+    }
+}
+
+pub fn write_evidence_binding(binding: &EvidenceV01Binding) -> Result<()> {
+    let log_dir = Path::new("evidence/logs");
+    if !log_dir.exists() {
+        create_dir_all(log_dir)?;
+    }
+    let log_path = log_dir.join("sidecar.jsonl");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)?;
+    let line = serde_json::to_string(binding)?;
+    writeln!(file, "{}", line)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binding_serializes_event_type() {
+        let b = EvidenceV01Binding::new("sess", "evidence/certs/sess/1.cert.json");
+        assert_eq!(b.event_type, "evidence_v01_binding");
+        assert_eq!(b.schema_version, "0.1");
+    }
+}

--- a/runtime/sidecar-watcher/src/evidence_v01.rs
+++ b/runtime/sidecar-watcher/src/evidence_v01.rs
@@ -60,11 +60,41 @@ pub fn write_evidence_binding(binding: &EvidenceV01Binding) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::io::{BufRead, BufReader};
+    use std::path::PathBuf;
 
     #[test]
     fn binding_serializes_event_type() {
         let b = EvidenceV01Binding::new("sess", "evidence/certs/sess/1.cert.json");
         assert_eq!(b.event_type, "evidence_v01_binding");
         assert_eq!(b.schema_version, "0.1");
+    }
+
+    #[test]
+    fn write_evidence_binding_produces_valid_jsonl() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        std::env::set_current_dir(tmp.path()).expect("chdir");
+
+        let binding = EvidenceV01Binding::new("sess-1", "evidence/certs/sess-1/1.cert.json")
+            .with_bundle_ref("examples/runtime-evidence-basic/basic-evidence-bundle.json")
+            .with_artifact_digest("cert-v1", "sha256:abc".to_string());
+
+        write_evidence_binding(&binding).expect("write binding");
+
+        let log_path = PathBuf::from("evidence/logs/sidecar.jsonl");
+        assert!(log_path.is_file(), "expected sidecar.jsonl");
+
+        let file = fs::File::open(&log_path).expect("open log");
+        let line = BufReader::new(file)
+            .lines()
+            .next()
+            .expect("one line")
+            .expect("read line");
+        let parsed: EvidenceV01Binding = serde_json::from_str(&line).expect("valid JSONL");
+        assert_eq!(parsed.event_type, "evidence_v01_binding");
+        assert_eq!(parsed.session_id, "sess-1");
+        assert!(parsed.evidence_bundle_ref.is_some());
+        assert!(parsed.artifact_digests.contains_key("cert-v1"));
     }
 }

--- a/runtime/sidecar-watcher/src/lib.rs
+++ b/runtime/sidecar-watcher/src/lib.rs
@@ -17,6 +17,7 @@ pub mod declassify;
 pub mod dfa;
 pub mod effects;
 pub mod egress_cert;
+pub mod evidence_v01;
 pub mod events;
 pub mod ifc_labels;
 pub mod label_witness;

--- a/runtime/sidecar-watcher/src/permit_enforcement.rs
+++ b/runtime/sidecar-watcher/src/permit_enforcement.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025 Provability-Fabric Contributors
 
-use crate::cert_v1::{write_cert, CertV1, MorphInfo};
+use crate::cert_v1::{write_cert_with_binding, CertV1, MorphInfo};
 use crate::policy_adapter::{
     self, EnforcementMode, PermissionResult, PolicyAdapter, PolicyConfig, Tool,
 };
@@ -211,8 +211,9 @@ impl PermitEnforcementHook {
         let session = &event.session_id;
         let seq = result.timestamp; // fallback; ideally monotonic seq
 
-        let path = write_cert(&cert, session, seq)?;
-        info!("CERT-V1 written: {}", path);
+        let bundle_ref = std::env::var("EVIDENCE_BUNDLE_REF").ok();
+        let path = write_cert_with_binding(&cert, session, seq, bundle_ref.as_deref())?;
+        info!("CERT-V1 written with Evidence v0.1 binding: {}", path);
         Ok(())
     }
 

--- a/tests/runtime_evidence/test_runtime_evidence_basic.py
+++ b/tests/runtime_evidence/test_runtime_evidence_basic.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime evidence basic scenario checks."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PF = REPO / "core" / "cli" / "pf" / "pf"
+EXAMPLE = REPO / "examples" / "runtime-evidence-basic"
+BUNDLE = EXAMPLE / "basic-evidence-bundle.json"
+BINDING = EXAMPLE / "binding-event.json"
+
+
+@pytest.fixture(scope="module")
+def pf_bin() -> Path:
+    if not PF.exists():
+        subprocess.run(["go", "build", "-o", "pf", "."], cwd=REPO / "core" / "cli" / "pf", check=True)
+    return PF
+
+
+def test_runtime_bundle_validates(pf_bin: Path) -> None:
+    proc = subprocess.run(
+        [str(pf_bin), "evidence", "validate", str(BUNDLE), "--strict"],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+
+
+def test_binding_event_shape() -> None:
+    event = json.loads(BINDING.read_text(encoding="utf-8"))
+    assert event["event_type"] == "evidence_v01_binding"
+    assert event["schema_version"] == "0.1"
+    assert "cert-v1" in event["artifact_digests"]
+    assert event["evidence_bundle_ref"].endswith("basic-evidence-bundle.json")
+
+
+def test_runtime_tampered_bundle_fails(pf_bin: Path, tmp_path: Path) -> None:
+    tampered = json.loads(BUNDLE.read_text(encoding="utf-8"))
+    tampered["bundle_digest"] = "sha256:" + "f" * 64
+    path = tmp_path / "tampered.json"
+    path.write_text(json.dumps(tampered, indent=2) + "\n", encoding="utf-8")
+    proc = subprocess.run(
+        [str(pf_bin), "evidence", "validate", str(path), "--strict", "--base-dir", str(EXAMPLE)],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode != 0

--- a/tests/runtime_evidence/test_runtime_evidence_basic.py
+++ b/tests/runtime_evidence/test_runtime_evidence_basic.py
@@ -5,7 +5,10 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -15,6 +18,14 @@ PF = REPO / "core" / "cli" / "pf" / "pf"
 EXAMPLE = REPO / "examples" / "runtime-evidence-basic"
 BUNDLE = EXAMPLE / "basic-evidence-bundle.json"
 BINDING = EXAMPLE / "binding-event.json"
+SCENARIO = EXAMPLE / "run_scenario.sh"
+
+
+def _bash_exe() -> str | None:
+    git_bash = Path(os.environ.get("ProgramFiles", r"C:\Program Files")) / "Git" / "bin" / "bash.exe"
+    if git_bash.is_file():
+        return str(git_bash)
+    return shutil.which("bash")
 
 
 @pytest.fixture(scope="module")
@@ -54,3 +65,11 @@ def test_runtime_tampered_bundle_fails(pf_bin: Path, tmp_path: Path) -> None:
         capture_output=True,
     )
     assert proc.returncode != 0
+
+
+@pytest.mark.skipif(_bash_exe() is None, reason="bash required")
+def test_run_scenario_static() -> None:
+    bash = _bash_exe()
+    assert bash is not None
+    proc = subprocess.run([bash, str(SCENARIO)], cwd=REPO, text=True, capture_output=True)
+    assert proc.returncode == 0, proc.stderr + proc.stdout

--- a/tests/runtime_evidence/test_runtime_evidence_binding.py
+++ b/tests/runtime_evidence/test_runtime_evidence_binding.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime evidence binding tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+BINDING = REPO / "examples" / "runtime-evidence-basic" / "binding-event.json"
+
+
+def test_binding_event_shape() -> None:
+    data = json.loads(BINDING.read_text(encoding="utf-8"))
+    assert data["event_type"] == "evidence_v01_binding"
+    assert "artifact_digests" in data

--- a/tests/runtime_evidence/test_runtime_evidence_binding.py
+++ b/tests/runtime_evidence/test_runtime_evidence_binding.py
@@ -5,13 +5,53 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
+import pytest
+
 REPO = Path(__file__).resolve().parents[2]
-BINDING = REPO / "examples" / "runtime-evidence-basic" / "binding-event.json"
+PF = REPO / "core" / "cli" / "pf" / "pf"
+EXAMPLE = REPO / "examples" / "runtime-evidence-basic"
+BUNDLE = EXAMPLE / "basic-evidence-bundle.json"
+BINDING = EXAMPLE / "binding-event.json"
+
+
+@pytest.fixture(scope="module")
+def pf_bin() -> Path:
+    if not PF.exists():
+        subprocess.run(["go", "build", "-o", "pf", "."], cwd=REPO / "core" / "cli" / "pf", check=True)
+    return PF
 
 
 def test_binding_event_shape() -> None:
     data = json.loads(BINDING.read_text(encoding="utf-8"))
     assert data["event_type"] == "evidence_v01_binding"
     assert "artifact_digests" in data
+
+
+def test_binding_bundle_validates_strict(pf_bin: Path) -> None:
+    proc = subprocess.run(
+        [str(pf_bin), "evidence", "validate", str(BUNDLE), "--strict", "--base-dir", str(EXAMPLE)],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+
+
+def test_binding_refs_resolve_in_bundle(pf_bin: Path) -> None:
+    binding = json.loads(BINDING.read_text(encoding="utf-8"))
+    bundle = json.loads(BUNDLE.read_text(encoding="utf-8"))
+    bundle_ref = binding["evidence_bundle_ref"]
+    assert bundle_ref.endswith("basic-evidence-bundle.json")
+    roles = {a["role"] for a in bundle["artifacts"]}
+    assert "attestation" in roles
+    assert "execution-trace" in roles
+    proc = subprocess.run(
+        [str(pf_bin), "evidence", "validate", str(BUNDLE), "--strict"],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0

--- a/tests/runtime_evidence/test_runtime_evidence_sidecar.py
+++ b/tests/runtime_evidence/test_runtime_evidence_sidecar.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Live sidecar binding integration (Linux CI + CERT-V1 schema gate).
+
+Skipped on Windows local runs; CI uses ubuntu-latest with submodules.
+"""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CERT_SCHEMA = REPO / "external" / "CERT-V1" / "schema" / "cert-v1.schema.json"
+SIDECAR_CRATE = REPO / "runtime" / "sidecar-watcher"
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="live sidecar test runs on Linux CI")
+@pytest.mark.skipif(not CERT_SCHEMA.is_file(), reason="CERT-V1 schema missing (make submodules)")
+def test_sidecar_write_cert_with_binding_emits_jsonl() -> None:
+    proc = subprocess.run(
+        [
+            "cargo",
+            "test",
+            "-p",
+            "sidecar-watcher",
+            "write_cert_with_binding_emits_binding_jsonl",
+            "--",
+            "--nocapture",
+        ],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert "evidence_v01_binding" in proc.stdout or proc.returncode == 0


### PR DESCRIPTION
## Summary
This PR advances the Evidence v0.1 path by emitting additive `evidence_v01_binding` JSONL events from the sidecar watcher without breaking CERT-V1 permit enforcement.

## Scope
- Add `runtime/sidecar-watcher/src/evidence_v01.rs` binding event emitter
- Extend `cert_v1.rs` and `permit_enforcement.rs` for additive hooks
- Rust unit tests: JSONL binding output, `write_cert_with_binding` with CERT-V1 gate
- Expand `tests/runtime_evidence/test_runtime_evidence_binding.py` (bundle strict validate)
- Add `tests/runtime_evidence/test_runtime_evidence_sidecar.py` (Linux + CERT-V1 live test)
- Add `docs/guides/runtime-evidence-basic.md` (emit path, CI requirements)

## Out of scope
- Runtime boundaries documentation, constrained scenario fixtures, replay workflow, and forensic examples

## Acceptance criteria
- [ ] Public artifact added or updated
- [ ] Tests or fixtures included
- [ ] Documentation updated
- [ ] Reproducible command included
- [ ] Known limitations documented

## Verification
```bash
cargo test -p sidecar-watcher -- write_evidence_binding write_cert_with_binding
pytest tests/runtime_evidence -q
```

## Notes for reviewers
Please focus review on: schema stability, validation behavior, artifact compatibility, reproducibility, failure modes.