### PR TITLE
examples: add constrained runtime evidence scenario

### DIFF
--- a/examples/runtime-evidence-basic/README.md
+++ b/examples/runtime-evidence-basic/README.md
@@ -1,0 +1,8 @@
+# Runtime evidence basic
+
+Demonstrates additive Evidence v0.1 binding alongside CERT-V1 sidecar emission.
+
+- `binding-event.json` — JSONL-shaped binding record emitted by `write_cert_with_binding`
+- `basic-evidence-bundle.json` — bundle referencing runtime artifacts
+
+See [Runtime evidence basic](../../docs/guides/runtime-evidence-basic.md).

--- a/examples/runtime-evidence-basic/README.md
+++ b/examples/runtime-evidence-basic/README.md
@@ -2,7 +2,25 @@
 
 Demonstrates additive Evidence v0.1 binding alongside CERT-V1 sidecar emission.
 
+## Static path (always)
+
+Checked-in fixtures — no live sidecar required:
+
 - `binding-event.json` — JSONL-shaped binding record emitted by `write_cert_with_binding`
 - `basic-evidence-bundle.json` — bundle referencing runtime artifacts
 
-See [Runtime evidence basic](../../docs/guides/runtime-evidence-basic.md).
+```bash
+bash examples/runtime-evidence-basic/run_scenario.sh
+```
+
+## Live path (optional)
+
+When `external/CERT-V1` is cloned (`make submodules`), exercise the permit-enforcement emit path:
+
+```bash
+bash examples/runtime-evidence-basic/run_scenario.sh --live
+```
+
+CI runs the live path via `tests/runtime_evidence/test_runtime_evidence_sidecar.py` on Linux when the CERT-V1 schema is present.
+
+See [Runtime evidence basic](../../docs/guides/runtime-evidence-basic.md) and the PR8 sidecar integration test.

--- a/examples/runtime-evidence-basic/artifacts/attestation.json
+++ b/examples/runtime-evidence-basic/artifacts/attestation.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "0.1",
+  "attestation_id": "attest-basic-001",
+  "attestor": "sidecar-watcher/demo",
+  "signed_claim_ref": {
+    "role": "proof",
+    "path": "artifacts/proof.json",
+    "media_type": "application/vnd.provability-fabric.evidence.proof+json",
+    "digest": "sha256:3c1435ff573801180594e2f0a2074b0e4d370bb6d84e9c4629a4b96e974fa5e9"
+  },
+  "signature": "demo-signature-placeholder"
+}

--- a/examples/runtime-evidence-basic/artifacts/claim.json
+++ b/examples/runtime-evidence-basic/artifacts/claim.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "0.1",
+  "claim_id": "claim-basic-001",
+  "statement": "Agent execution stayed within declared policy bounds for the demo session.",
+  "subject": {
+    "agent_id": "demo-agent",
+    "session_id": "sess-001"
+  }
+}

--- a/examples/runtime-evidence-basic/artifacts/execution-trace.json
+++ b/examples/runtime-evidence-basic/artifacts/execution-trace.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "0.1",
+  "trace_id": "trace-basic-001",
+  "events": [
+    {
+      "seq": 0,
+      "kind": "run_started",
+      "detail": "demo session"
+    },
+    {
+      "seq": 1,
+      "kind": "policy_checked",
+      "detail": "permit accept"
+    }
+  ],
+  "trace_digest": "sha256:09e991995ed1561fe58d2d597537cc72436a5c360118cca284e795f495d1210b"
+}

--- a/examples/runtime-evidence-basic/artifacts/proof.json
+++ b/examples/runtime-evidence-basic/artifacts/proof.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "0.1",
+  "proof_id": "proof-basic-001",
+  "proof_system": "lean4",
+  "artifact_refs": [
+    {
+      "role": "claim",
+      "path": "artifacts/claim.json",
+      "media_type": "application/vnd.provability-fabric.evidence.claim+json",
+      "digest": "sha256:09b99e794ee3a38346bc692ddab77c5b9b95d7c82526d6b19b176f64f3e17f3e"
+    }
+  ],
+  "proof_digest": "sha256:ac5d2e7a13046cdae7a22c4b7a00abdbd6302c2514d5f6607a17234a2c2fdec1"
+}

--- a/examples/runtime-evidence-basic/basic-evidence-bundle.json
+++ b/examples/runtime-evidence-basic/basic-evidence-bundle.json
@@ -1,0 +1,33 @@
+{
+  "bundle_id": "basic-evidence-bundle",
+  "schema_version": "0.1",
+  "created_at": "2025-06-01T12:00:00Z",
+  "producer": "pf-evidence/v0.1",
+  "artifacts": [
+    {
+      "role": "claim",
+      "path": "artifacts/claim.json",
+      "media_type": "application/vnd.provability-fabric.evidence.claim+json",
+      "digest": "sha256:09b99e794ee3a38346bc692ddab77c5b9b95d7c82526d6b19b176f64f3e17f3e"
+    },
+    {
+      "role": "proof",
+      "path": "artifacts/proof.json",
+      "media_type": "application/vnd.provability-fabric.evidence.proof+json",
+      "digest": "sha256:c321e0bfcc750ca2bc7ab7a38ae7b1d97c7af423d80d49cbb3e0a62921a1f3e2"
+    },
+    {
+      "role": "attestation",
+      "path": "artifacts/attestation.json",
+      "media_type": "application/vnd.provability-fabric.evidence.attestation+json",
+      "digest": "sha256:94f7446165c3d48821d4ec658617ada293c4f78f56ba0794096329745f83f174"
+    },
+    {
+      "role": "execution-trace",
+      "path": "artifacts/execution-trace.json",
+      "media_type": "application/vnd.provability-fabric.evidence.execution-trace+json",
+      "digest": "sha256:187bfebdae04f46b88c37dce8f6d99d877d43fe4d65c641a2b4903cd7ff6497a"
+    }
+  ],
+  "bundle_digest": "sha256:d5ee274690ecac4e87e0996f3add1419354c4dd75a042f649557980bb065d0cf"
+}

--- a/examples/runtime-evidence-basic/binding-event.json
+++ b/examples/runtime-evidence-basic/binding-event.json
@@ -1,0 +1,10 @@
+{
+  "event_type": "evidence_v01_binding",
+  "session_id": "runtime-demo-001",
+  "cert_path": "evidence/certs/runtime-demo-001/1.cert.json",
+  "evidence_bundle_ref": "examples/runtime-evidence-basic/basic-evidence-bundle.json",
+  "artifact_digests": {
+    "cert-v1": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "schema_version": "0.1"
+}

--- a/examples/runtime-evidence-basic/manifest.json
+++ b/examples/runtime-evidence-basic/manifest.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "0.1",
+  "bundle_id": "basic-evidence-bundle",
+  "producer": "pf-evidence/v0.1",
+  "created_at": "2025-06-01T12:00:00Z",
+  "artifacts": [
+    { "role": "claim", "path": "artifacts/claim.json" },
+    { "role": "proof", "path": "artifacts/proof.json" },
+    { "role": "attestation", "path": "artifacts/attestation.json" },
+    { "role": "execution-trace", "path": "artifacts/execution-trace.json" }
+  ]
+}

--- a/examples/runtime-evidence-basic/run_scenario.sh
+++ b/examples/runtime-evidence-basic/run_scenario.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Runtime evidence basic scenario: static validation (always) + optional live sidecar emit.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+PF="${PF:-./core/cli/pf/pf}"
+if [[ ! -x "$PF" ]]; then
+  (cd core/cli/pf && go build -o pf .)
+  PF="./core/cli/pf/pf"
+fi
+
+EXAMPLE="examples/runtime-evidence-basic"
+BUNDLE="$EXAMPLE/basic-evidence-bundle.json"
+BINDING="$EXAMPLE/binding-event.json"
+
+echo "== Step 1: static bundle + binding shape =="
+"$PF" evidence validate "$BUNDLE" --strict --base-dir "$EXAMPLE"
+grep -q '"event_type": "evidence_v01_binding"' "$BINDING"
+grep -q '"schema_version": "0.1"' "$BINDING"
+grep -q '"artifact_digests"' "$BINDING"
+echo "binding-event.json shape OK"
+
+if [[ "${1:-}" != "--live" ]]; then
+  echo "Static scenario complete (pass --live for sidecar emit path)."
+  exit 0
+fi
+
+echo "== Step 2: live sidecar emit (CERT-V1 required) =="
+SCHEMA="external/CERT-V1/schema/cert-v1.schema.json"
+if [[ ! -f "$SCHEMA" ]]; then
+  echo "CERT-V1 schema missing at $SCHEMA — run: make submodules" >&2
+  exit 1
+fi
+
+cargo test -p sidecar-watcher write_cert_with_binding_emits_binding_jsonl -- --nocapture
+echo "Live scenario complete."


### PR DESCRIPTION
## Summary
This PR advances the Evidence v0.1 path by adding `examples/runtime-evidence-basic` with a binding event fixture and pytest coverage for the constrained runtime evidence scenario.

## Scope
- Add `examples/runtime-evidence-basic/` bundle artifacts, manifest, and `binding-event.json`
- Add `run_scenario.sh` (static validation + optional `--live` sidecar emit)
- Extend runtime evidence tests with `test_runtime_evidence_basic.py` (scenario script wiring)

## Out of scope
- Replay verification CLI, forensic tamper walkthrough, testbed scripts, and onboarding docs

## Acceptance criteria
- [ ] Public artifact added or updated
- [ ] Tests or fixtures included
- [ ] Documentation updated
- [ ] Reproducible command included
- [ ] Known limitations documented

## Verification
```bash
bash examples/runtime-evidence-basic/run_scenario.sh
pytest tests/runtime_evidence/test_runtime_evidence_basic.py -q
```

## Notes for reviewers
Please focus review on: schema stability, validation behavior, artifact compatibility, reproducibility, failure modes.