### PR TITLE
replay: add Evidence v0.1 replay verification workflow

### DIFF
--- a/core/cli/pf/evidence_commands.go
+++ b/core/cli/pf/evidence_commands.go
@@ -15,11 +15,12 @@ import (
 func evidenceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "evidence",
-		Short: "Evidence v0.1 bundle pack and validate",
-		Long:  "Pack and validate Evidence v0.1 JSON bundles (distinct from PCS EvidenceBundle.v0 and so bundle pack tar archives).",
+		Short: "Evidence v0.1 bundle pack, validate, and replay",
+		Long:  "Pack, validate, and replay Evidence v0.1 JSON bundles (distinct from PCS EvidenceBundle.v0 and so bundle pack tar archives).",
 	}
 	cmd.AddCommand(evidenceBundleCmd())
 	cmd.AddCommand(evidenceValidateCmd())
+	cmd.AddCommand(evidenceReplayCmd())
 	return cmd
 }
 
@@ -109,5 +110,41 @@ func evidenceValidateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&baseDir, "base-dir", "", "Directory containing artifact paths (default: bundle directory)")
 	cmd.Flags().StringVar(&reportOut, "report-out", "", "Write validation report JSON")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit validation report JSON to stdout")
+	return cmd
+}
+
+func evidenceReplayCmd() *cobra.Command {
+	var outPath string
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "replay",
+		Short: "Verify replay preconditions for an Evidence v0.1 bundle",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bundlePath, _ := cmd.Flags().GetString("bundle")
+			if bundlePath == "" {
+				return fmt.Errorf("--bundle is required")
+			}
+			report, err := evidence.ReplayBundle(evidence.ReplayOptions{
+				BundlePath: bundlePath,
+				OutPath:    outPath,
+			})
+			if jsonOut {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				_ = enc.Encode(report)
+			} else {
+				fmt.Printf("status: %s trace_found=%v\n", report.Status, report.TraceFound)
+				for _, msg := range report.Errors {
+					fmt.Printf("error: %s\n", msg)
+				}
+			}
+			return err
+		},
+	}
+	cmd.Flags().String("bundle", "", "Path to Evidence v0.1 bundle JSON")
+	_ = cmd.MarkFlagRequired("bundle")
+	cmd.Flags().StringVar(&outPath, "out", "", "Write replay report JSON")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit replay report JSON to stdout")
 	return cmd
 }

--- a/core/evidence/replay.go
+++ b/core/evidence/replay.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+package evidence
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ReplayReport captures replay verification output for a v0.1 bundle.
+type ReplayReport struct {
+	ReportID    string   `json:"report_id"`
+	BundleRef   string   `json:"bundle_ref"`
+	Status      string   `json:"status"`
+	TraceFound  bool     `json:"trace_found"`
+	Errors      []string `json:"errors"`
+	Warnings    []string `json:"warnings"`
+	ReplayedAt  string   `json:"replayed_at"`
+}
+
+// ReplayOptions configures replay verification.
+type ReplayOptions struct {
+	BundlePath string
+	OutPath    string
+	Strict     bool
+	RepoRoot   string
+	BaseDir    string
+}
+
+// ReplayBundle validates a bundle and verifies replay preconditions for execution traces.
+func ReplayBundle(opts ReplayOptions) (*ReplayReport, error) {
+	if opts.BaseDir == "" {
+		opts.BaseDir = filepath.Dir(opts.BundlePath)
+	}
+	report := &ReplayReport{
+		ReportID:   fmt.Sprintf("replay-%d", time.Now().UTC().UnixNano()),
+		BundleRef:  filepath.ToSlash(opts.BundlePath),
+		Status:     "pass",
+		Errors:     []string{},
+		Warnings:   []string{},
+		ReplayedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	valReport, err := ValidateBundle(ValidateOptions{
+		BundlePath: opts.BundlePath,
+		Strict:     true,
+		RepoRoot:   opts.RepoRoot,
+		BaseDir:    opts.BaseDir,
+	})
+	if err != nil {
+		report.Status = "fail"
+		report.Errors = append(report.Errors, valReport.Errors...)
+		if len(report.Errors) == 0 {
+			report.Errors = append(report.Errors, err.Error())
+		}
+		return report, err
+	}
+	report.Warnings = append(report.Warnings, valReport.Warnings...)
+
+	data, err := os.ReadFile(opts.BundlePath)
+	if err != nil {
+		report.Status = "fail"
+		report.Errors = append(report.Errors, err.Error())
+		return report, err
+	}
+	var bundle EvidenceBundle
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		report.Status = "fail"
+		report.Errors = append(report.Errors, err.Error())
+		return report, err
+	}
+
+	traceFound := false
+	for _, ref := range bundle.Artifacts {
+		if ref.Role != "execution-trace" {
+			continue
+		}
+		traceFound = true
+		tracePath := filepath.Join(opts.BaseDir, filepath.FromSlash(ref.Path))
+		traceData, readErr := os.ReadFile(tracePath)
+		if readErr != nil {
+			report.Status = "fail"
+			report.Errors = append(report.Errors, readErr.Error())
+			return report, readErr
+		}
+		var trace map[string]any
+		if err := json.Unmarshal(traceData, &trace); err != nil {
+			report.Status = "fail"
+			report.Errors = append(report.Errors, fmt.Sprintf("invalid execution trace JSON: %v", err))
+			return report, err
+		}
+		expected, err := CanonicalJSONDigest(trace, "trace_digest")
+		if err != nil {
+			report.Status = "fail"
+			report.Errors = append(report.Errors, err.Error())
+			return report, err
+		}
+		actual, _ := trace["trace_digest"].(string)
+		if actual != expected {
+			msg := fmt.Errorf("trace_digest mismatch: expected %s got %s", expected, actual)
+			report.Status = "fail"
+			report.Errors = append(report.Errors, msg.Error())
+			return report, msg
+		}
+	}
+	report.TraceFound = traceFound
+	if !traceFound {
+		report.Warnings = append(report.Warnings, "no execution-trace artifact; replay preconditions only partially satisfied")
+	}
+
+	if opts.OutPath != "" {
+		if err := WriteReplayReport(opts.OutPath, report); err != nil {
+			return report, err
+		}
+	}
+	if report.Status == "fail" {
+		return report, fmt.Errorf("replay verification failed")
+	}
+	return report, nil
+}
+
+// WriteReplayReport writes replay report JSON.
+func WriteReplayReport(path string, report *ReplayReport) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0644)
+}

--- a/core/evidence/replay_test.go
+++ b/core/evidence/replay_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+package evidence
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestReplayValidFixture(t *testing.T) {
+	root := repoRoot(t)
+	bundlePath := filepath.Join(root, "specs", "evidence", "v0.1", "examples", "valid", "basic-evidence-bundle.json")
+	out := filepath.Join(t.TempDir(), "replay-report.json")
+	report, err := ReplayBundle(ReplayOptions{
+		BundlePath: bundlePath,
+		OutPath:    out,
+		RepoRoot:   root,
+		BaseDir:    filepath.Dir(bundlePath),
+	})
+	if err != nil {
+		t.Fatalf("replay: %v (%v)", err, report.Errors)
+	}
+	if !report.TraceFound {
+		t.Fatal("expected execution trace in fixture bundle")
+	}
+}
+
+func TestReplayTamperedDigestFails(t *testing.T) {
+	root := repoRoot(t)
+	bad := filepath.Join(root, "specs", "evidence", "v0.1", "examples", "invalid", "bad-bundle-digest.json")
+	_, err := ReplayBundle(ReplayOptions{
+		BundlePath: bad,
+		RepoRoot:   root,
+		BaseDir:    filepath.Dir(bad),
+	})
+	if err == nil {
+		t.Fatal("expected replay failure for tampered bundle")
+	}
+}

--- a/tests/evidence_replay/test_evidence_replay.py
+++ b/tests/evidence_replay/test_evidence_replay.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Evidence replay CLI tests."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PF = REPO / "core" / "cli" / "pf" / "pf"
+VALID = REPO / "specs" / "evidence" / "v0.1" / "examples" / "valid" / "basic-evidence-bundle.json"
+INVALID = REPO / "specs" / "evidence" / "v0.1" / "examples" / "invalid" / "bad-bundle-digest.json"
+
+
+@pytest.fixture(scope="module")
+def pf_bin() -> Path:
+    if not PF.exists():
+        subprocess.run(["go", "build", "-o", "pf", "."], cwd=REPO / "core" / "cli" / "pf", check=True)
+    return PF
+
+
+def test_replay_valid(pf_bin: Path, tmp_path: Path) -> None:
+    out = tmp_path / "replay.json"
+    proc = subprocess.run(
+        [str(pf_bin), "evidence", "replay", "--bundle", str(VALID), "--out", str(out)],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+
+
+def test_replay_tampered_fails(pf_bin: Path) -> None:
+    proc = subprocess.run(
+        [str(pf_bin), "evidence", "replay", "--bundle", str(INVALID)],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode != 0


### PR DESCRIPTION
## Summary
This PR advances the Evidence v0.1 path by implementing `core/evidence/replay.go` and `pf evidence replay` to verify bundle integrity and artifact digests after packaging.

## Scope
- Add `core/evidence/replay.go` and Go unit tests
- Wire `pf evidence replay` in `evidence_commands.go`
- Add `tests/evidence_replay/test_evidence_replay.py`

## Out of scope
- Replay guarantees documentation, forensic tamper examples, testbed CI, and onboarding release notes

## Acceptance criteria
- [ ] Public artifact added or updated
- [ ] Tests or fixtures included
- [ ] Documentation updated
- [ ] Reproducible command included
- [ ] Known limitations documented

## Verification
```bash
pytest tests/evidence_replay -q
```

## Notes for reviewers
Please focus review on: schema stability, validation behavior, artifact compatibility, reproducibility, failure modes.