### PR TITLE
examples: add forensic replay example

### DIFF
--- a/docs/guides/forensic-replay-basic.md
+++ b/docs/guides/forensic-replay-basic.md
@@ -1,0 +1,34 @@
+# Forensic replay basic
+
+Walkthrough for pass and tamper cases using `examples/forensic-replay-basic/`.
+
+## Passing case
+
+```bash
+pf evidence replay --bundle examples/forensic-replay-basic/basic-evidence-bundle.json
+```
+
+Expect exit code 0 and `trace_found=true` when the bundle includes an execution trace.
+
+## Tampered case
+
+`tampered-bundle.json` contains an invalid `bundle_digest`.
+
+```bash
+pf evidence replay --bundle examples/forensic-replay-basic/tampered-bundle.json
+echo exit:$?
+```
+
+Expect non-zero exit — strict validation fails closed.
+
+## Testbed
+
+```bash
+bash testbed/evidence-v0.1/run_tamper_case.sh
+pytest tests/forensic_replay/test_forensic_replay_basic.py -q
+```
+
+## Related
+
+- [Replay guarantees](replay-guarantees.md)
+- [Evidence v0.1 quickstart](evidence-v0.1-quickstart.md)

--- a/examples/forensic-replay-basic/README.md
+++ b/examples/forensic-replay-basic/README.md
@@ -1,0 +1,10 @@
+# Forensic replay basic
+
+Contains a passing bundle and a tampered bundle (`tampered-bundle.json`) with an invalid `bundle_digest`.
+
+```bash
+pf evidence replay --bundle examples/forensic-replay-basic/basic-evidence-bundle.json
+pf evidence replay --bundle examples/forensic-replay-basic/tampered-bundle.json || true
+```
+
+See [Forensic replay basic](../../docs/guides/forensic-replay-basic.md).

--- a/examples/forensic-replay-basic/artifacts/attestation.json
+++ b/examples/forensic-replay-basic/artifacts/attestation.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "0.1",
+  "attestation_id": "attest-basic-001",
+  "attestor": "sidecar-watcher/demo",
+  "signed_claim_ref": {
+    "role": "proof",
+    "path": "artifacts/proof.json",
+    "media_type": "application/vnd.provability-fabric.evidence.proof+json",
+    "digest": "sha256:3c1435ff573801180594e2f0a2074b0e4d370bb6d84e9c4629a4b96e974fa5e9"
+  },
+  "signature": "demo-signature-placeholder"
+}

--- a/examples/forensic-replay-basic/artifacts/claim.json
+++ b/examples/forensic-replay-basic/artifacts/claim.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "0.1",
+  "claim_id": "claim-basic-001",
+  "statement": "Agent execution stayed within declared policy bounds for the demo session.",
+  "subject": {
+    "agent_id": "demo-agent",
+    "session_id": "sess-001"
+  }
+}

--- a/examples/forensic-replay-basic/artifacts/execution-trace.json
+++ b/examples/forensic-replay-basic/artifacts/execution-trace.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "0.1",
+  "trace_id": "trace-basic-001",
+  "events": [
+    {
+      "seq": 0,
+      "kind": "run_started",
+      "detail": "demo session"
+    },
+    {
+      "seq": 1,
+      "kind": "policy_checked",
+      "detail": "permit accept"
+    }
+  ],
+  "trace_digest": "sha256:09e991995ed1561fe58d2d597537cc72436a5c360118cca284e795f495d1210b"
+}

--- a/examples/forensic-replay-basic/artifacts/proof.json
+++ b/examples/forensic-replay-basic/artifacts/proof.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "0.1",
+  "proof_id": "proof-basic-001",
+  "proof_system": "lean4",
+  "artifact_refs": [
+    {
+      "role": "claim",
+      "path": "artifacts/claim.json",
+      "media_type": "application/vnd.provability-fabric.evidence.claim+json",
+      "digest": "sha256:09b99e794ee3a38346bc692ddab77c5b9b95d7c82526d6b19b176f64f3e17f3e"
+    }
+  ],
+  "proof_digest": "sha256:ac5d2e7a13046cdae7a22c4b7a00abdbd6302c2514d5f6607a17234a2c2fdec1"
+}

--- a/examples/forensic-replay-basic/basic-evidence-bundle.json
+++ b/examples/forensic-replay-basic/basic-evidence-bundle.json
@@ -1,0 +1,33 @@
+{
+  "bundle_id": "basic-evidence-bundle",
+  "schema_version": "0.1",
+  "created_at": "2025-06-01T12:00:00Z",
+  "producer": "pf-evidence/v0.1",
+  "artifacts": [
+    {
+      "role": "claim",
+      "path": "artifacts/claim.json",
+      "media_type": "application/vnd.provability-fabric.evidence.claim+json",
+      "digest": "sha256:09b99e794ee3a38346bc692ddab77c5b9b95d7c82526d6b19b176f64f3e17f3e"
+    },
+    {
+      "role": "proof",
+      "path": "artifacts/proof.json",
+      "media_type": "application/vnd.provability-fabric.evidence.proof+json",
+      "digest": "sha256:c321e0bfcc750ca2bc7ab7a38ae7b1d97c7af423d80d49cbb3e0a62921a1f3e2"
+    },
+    {
+      "role": "attestation",
+      "path": "artifacts/attestation.json",
+      "media_type": "application/vnd.provability-fabric.evidence.attestation+json",
+      "digest": "sha256:94f7446165c3d48821d4ec658617ada293c4f78f56ba0794096329745f83f174"
+    },
+    {
+      "role": "execution-trace",
+      "path": "artifacts/execution-trace.json",
+      "media_type": "application/vnd.provability-fabric.evidence.execution-trace+json",
+      "digest": "sha256:187bfebdae04f46b88c37dce8f6d99d877d43fe4d65c641a2b4903cd7ff6497a"
+    }
+  ],
+  "bundle_digest": "sha256:d5ee274690ecac4e87e0996f3add1419354c4dd75a042f649557980bb065d0cf"
+}

--- a/examples/forensic-replay-basic/manifest.json
+++ b/examples/forensic-replay-basic/manifest.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "0.1",
+  "bundle_id": "basic-evidence-bundle",
+  "producer": "pf-evidence/v0.1",
+  "created_at": "2025-06-01T12:00:00Z",
+  "artifacts": [
+    { "role": "claim", "path": "artifacts/claim.json" },
+    { "role": "proof", "path": "artifacts/proof.json" },
+    { "role": "attestation", "path": "artifacts/attestation.json" },
+    { "role": "execution-trace", "path": "artifacts/execution-trace.json" }
+  ]
+}

--- a/examples/forensic-replay-basic/tampered-bundle.json
+++ b/examples/forensic-replay-basic/tampered-bundle.json
@@ -1,0 +1,33 @@
+{
+  "bundle_id": "basic-evidence-bundle",
+  "schema_version": "0.1",
+  "created_at": "2025-06-01T12:00:00Z",
+  "producer": "pf-evidence/v0.1",
+  "artifacts": [
+    {
+      "role": "claim",
+      "path": "artifacts/claim.json",
+      "media_type": "application/vnd.provability-fabric.evidence.claim+json",
+      "digest": "sha256:09b99e794ee3a38346bc692ddab77c5b9b95d7c82526d6b19b176f64f3e17f3e"
+    },
+    {
+      "role": "proof",
+      "path": "artifacts/proof.json",
+      "media_type": "application/vnd.provability-fabric.evidence.proof+json",
+      "digest": "sha256:3c1435ff573801180594e2f0a2074b0e4d370bb6d84e9c4629a4b96e974fa5e9"
+    },
+    {
+      "role": "attestation",
+      "path": "artifacts/attestation.json",
+      "media_type": "application/vnd.provability-fabric.evidence.attestation+json",
+      "digest": "sha256:e54289083d4e13ede6956d22bbc525659c2d17255c7908442dcf362887d675ef"
+    },
+    {
+      "role": "execution-trace",
+      "path": "artifacts/execution-trace.json",
+      "media_type": "application/vnd.provability-fabric.evidence.execution-trace+json",
+      "digest": "sha256:b4c252325a6b850675891db80148489bee7c1ef0c45d994e76818e5a5cf95e78"
+    }
+  ],
+  "bundle_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+}

--- a/tests/forensic_replay/test_forensic_replay_basic.py
+++ b/tests/forensic_replay/test_forensic_replay_basic.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Forensic replay example tests."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PF = REPO / "core" / "cli" / "pf" / "pf"
+PASS = REPO / "examples" / "forensic-replay-basic" / "basic-evidence-bundle.json"
+TAMPER = REPO / "examples" / "forensic-replay-basic" / "tampered-bundle.json"
+
+
+@pytest.fixture(scope="module")
+def pf_bin() -> Path:
+    if not PF.exists():
+        subprocess.run(["go", "build", "-o", "pf", "."], cwd=REPO / "core" / "cli" / "pf", check=True)
+    return PF
+
+
+def test_forensic_pass_case(pf_bin: Path) -> None:
+    proc = subprocess.run(
+        [str(pf_bin), "evidence", "replay", "--bundle", str(PASS)],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_forensic_tamper_case(pf_bin: Path) -> None:
+    proc = subprocess.run(
+        [str(pf_bin), "evidence", "replay", "--bundle", str(TAMPER)],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode != 0


### PR DESCRIPTION
## Summary
This PR advances the Evidence v0.1 path by adding a forensic replay walkthrough with pass and tampered bundles plus pytest coverage for digest mismatch detection.

## Scope
- Add `examples/forensic-replay-basic/` with valid and `tampered-bundle.json` fixtures
- Add `docs/guides/forensic-replay-basic.md`
- Add `tests/forensic_replay/test_forensic_replay_basic.py`

## Out of scope
- Testbed shell scripts, CI smoke workflow, and onboarding release notes

## Acceptance criteria
- [ ] Public artifact added or updated
- [ ] Tests or fixtures included
- [ ] Documentation updated
- [ ] Reproducible command included
- [ ] Known limitations documented

## Verification
```bash
pytest tests/forensic_replay -q
```

## Notes for reviewers
Please focus review on: schema stability, validation behavior, artifact compatibility, reproducibility, failure modes.