### PR TITLE
testbed: add Evidence v0.1 reproducible workflows

### DIFF
--- a/.github/workflows/evidence-v01-smoke.yml
+++ b/.github/workflows/evidence-v01-smoke.yml
@@ -1,13 +1,22 @@
-﻿name: Evidence v0.1 smoke
+name: Evidence v0.1 smoke
 
 on:
   pull_request:
     paths:
       - 'specs/evidence/**'
-      - 'tests/evidence_schema/**'
       - 'core/evidence/**'
-      - 'tests/evidence_validation/**'
       - 'core/cli/pf/evidence_commands.go'
+      - 'core/cli/pf/main.go'
+      - 'runtime/sidecar-watcher/src/evidence_v01.rs'
+      - 'runtime/sidecar-watcher/src/cert_v1.rs'
+      - 'runtime/sidecar-watcher/src/permit_enforcement.rs'
+      - 'testbed/evidence-v0.1/**'
+      - 'tests/evidence_**/**'
+      - 'tests/e2e/test_evidence_bundle_basic.py'
+      - 'tests/runtime_evidence/**'
+      - 'tests/forensic_replay/**'
+      - 'tests/testbed/test_evidence_v01_testbed.py'
+      - 'tools/cert-validate/validate.py'
       - '.github/workflows/evidence-v01-smoke.yml'
   push:
     branches: [main]
@@ -27,24 +36,97 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install jsonschema pytest
-      - run: pytest tests/evidence_schema -q
+
+      - name: Install Python deps
+        run: pip install jsonschema pytest
+
+      - name: Pytest evidence schema
+        run: pytest tests/evidence_schema -q
 
   evidence-validator:
     runs-on: ubuntu-latest
     needs: evidence-schema-only
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-go@v5
         with:
           go-version: '1.23'
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install jsonschema pytest
-      - run: go test ./...
+
+      - name: Install Python deps
+        run: pip install jsonschema pytest
+
+      - name: Go tests (core/evidence)
+        run: go test ./...
         working-directory: core/evidence
-      - run: pytest tests/evidence_validation -q
+
+      - name: Pytest evidence validation
+        run: pytest tests/evidence_validation -q
+
+  smoke:
+    runs-on: ubuntu-latest
+    needs: evidence-validator
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python deps
+        run: pip install jsonschema pytest
+
+      - name: Go tests (core/evidence)
+        run: go test ./...
+        working-directory: core/evidence
+
+      - name: Build pf CLI
+        run: go build -o pf .
+        working-directory: core/cli/pf
+
+      - name: Validate fixture bundle (strict)
+        run: |
+          ./core/cli/pf/pf evidence validate \
+            specs/evidence/v0.1/examples/valid/basic-evidence-bundle.json \
+            --strict \
+            --base-dir specs/evidence/v0.1/examples/valid
+
+      - name: Pytest evidence suites
+        run: |
+          pytest tests/evidence_schema -q
+          pytest tests/evidence_validation -q
+          pytest tests/evidence_replay -q
+          pytest tests/e2e/test_evidence_bundle_basic.py -q
+          pytest tests/runtime_evidence -q
+          pytest tests/forensic_replay -q
+
+      - name: Testbed happy path
+        run: bash testbed/evidence-v0.1/run_happy_path.sh
+
+      - name: Testbed tamper case
+        run: bash testbed/evidence-v0.1/run_tamper_case.sh
+
+      - name: Pytest testbed wrapper
+        run: pytest tests/testbed/test_evidence_v01_testbed.py -q
+
+      - name: Runtime sidecar binding (Linux + CERT-V1)
+        run: |
+          if [ -f external/CERT-V1/schema/cert-v1.schema.json ]; then
+            pytest tests/runtime_evidence/test_runtime_evidence_sidecar.py -q
+          else
+            echo "CERT-V1 schema missing; skipping live sidecar test"
+          fi

--- a/testbed/evidence-v0.1/run_happy_path.sh
+++ b/testbed/evidence-v0.1/run_happy_path.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PF="$ROOT/core/cli/pf/pf"
+BUNDLE="$ROOT/specs/evidence/v0.1/examples/valid/basic-evidence-bundle.json"
+
+if [[ ! -x "$PF" ]]; then
+  (cd "$ROOT/core/cli/pf" && go build -o pf .)
+fi
+
+"$PF" evidence validate "$BUNDLE" --strict
+"$PF" evidence replay --bundle "$BUNDLE" --out "$ROOT/testbed/evidence-v0.1/out/replay-report.json"
+echo "evidence-v0.1 happy path OK"

--- a/testbed/evidence-v0.1/run_tamper_case.sh
+++ b/testbed/evidence-v0.1/run_tamper_case.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PF="$ROOT/core/cli/pf/pf"
+TAMPER="$ROOT/specs/evidence/v0.1/examples/invalid/bad-bundle-digest.json"
+
+if [[ ! -x "$PF" ]]; then
+  (cd "$ROOT/core/cli/pf" && go build -o pf .)
+fi
+
+set +e
+"$PF" evidence validate "$TAMPER" --strict
+code=$?
+set -e
+if [[ "$code" -eq 0 ]]; then
+  echo "expected tamper validation failure" >&2
+  exit 1
+fi
+echo "evidence-v0.1 tamper case OK"

--- a/tests/testbed/test_evidence_v01_testbed.py
+++ b/tests/testbed/test_evidence_v01_testbed.py
@@ -1,0 +1,43 @@
+﻿#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Public testbed wrapper tests."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+TESTBED = REPO / "testbed" / "evidence-v0.1"
+
+
+def _bash_exe() -> str | None:
+    git_bash = Path(os.environ.get("ProgramFiles", r"C:\Program Files")) / "Git" / "bin" / "bash.exe"
+    if git_bash.is_file():
+        return str(git_bash)
+    return shutil.which("bash")
+
+
+def _run_testbed_script(name: str) -> subprocess.CompletedProcess[str]:
+    bash = _bash_exe()
+    assert bash is not None
+    # Use a repo-relative path so Git Bash on Windows can execute the script.
+    script = f"testbed/evidence-v0.1/{name}"
+    return subprocess.run([bash, "-c", f"bash {script}"], cwd=REPO, text=True)
+
+
+@pytest.mark.skipif(_bash_exe() is None, reason="bash required")
+def test_happy_path_script() -> None:
+    proc = _run_testbed_script("run_happy_path.sh")
+    assert proc.returncode == 0
+
+
+@pytest.mark.skipif(_bash_exe() is None, reason="bash required")
+def test_tamper_script() -> None:
+    proc = _run_testbed_script("run_tamper_case.sh")
+    assert proc.returncode == 0


### PR DESCRIPTION
## Summary
This PR advances the Evidence v0.1 path by adding reproducible testbed shell scripts and a CI smoke workflow that exercises happy-path pack/validate/replay and tamper detection.

## Scope
- Add `testbed/evidence-v0.1/run_happy_path.sh` and `run_tamper_case.sh`
- Add `tests/testbed/test_evidence_v01_testbed.py`
- Complete `.github/workflows/evidence-v01-smoke.yml`: full smoke + runtime sidecar step (builds on PR4/PR6 progressive jobs)

## Out of scope
- Onboarding quickstart, CHANGELOG release notes, and mkdocs nav finalization

## Acceptance criteria
- [ ] Public artifact added or updated
- [ ] Tests or fixtures included
- [ ] Documentation updated
- [ ] Reproducible command included
- [ ] Known limitations documented

## Verification
```bash
bash testbed/evidence-v0.1/run_happy_path.sh
bash testbed/evidence-v0.1/run_tamper_case.sh
pytest tests/testbed -q
```

## Notes for reviewers
Please focus review on: schema stability, validation behavior, artifact compatibility, reproducibility, failure modes.