### PR TITLE
Evidence v0.2: external standards submodules and pin-check

### DIFF
--- a/.github/workflows/standards-pin.yml
+++ b/.github/workflows/standards-pin.yml
@@ -6,12 +6,16 @@ on:
     paths:
       - "external/**"
       - "tools/standards/**"
+      - ".gitmodules"
+      - "Makefile"
       - ".github/workflows/standards-pin.yml"
   pull_request:
     branches: [main, develop]
     paths:
       - "external/**"
       - "tools/standards/**"
+      - ".gitmodules"
+      - "Makefile"
       - ".github/workflows/standards-pin.yml"
   workflow_dispatch:
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,8 @@
+[submodule "external/CERT-V1"]
+	path = external/CERT-V1
+	url = https://github.com/verifiable-ai-ci/CERT-V1.git
+	branch = v1.0.0
+[submodule "external/TRACE-REPLAY-KIT"]
+	path = external/TRACE-REPLAY-KIT
+	url = https://github.com/verifiable-ai-ci/TRACE-REPLAY-KIT.git
+	branch = v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,9 @@ For the full pull request and review process, see [Governance - Pull Request Pro
 If you only need the CLI and spec/bundle workflow (no Rust, Node, or Docker):
 
 ```bash
+git clone --recurse-submodules https://github.com/SentinelOps-CI/provability-fabric.git
+cd provability-fabric
+make dev-standards   # CERT-V1 + TRACE-REPLAY-KIT for evidence/replay tests
 # Requires Go 1.23+ (see core/cli/pf/go.mod)
 cd core/cli/pf && go build -o pf . && cd ../../..
 # Add the binary to your PATH; on Windows the output is pf.exe

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ dev-up:
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2025 SentinelOps Platform Contributors
 
-.PHONY: help build test clean demo-up demo-down demo-setup install dev validate-certs lint bench security test-all helm-install helm-upgrade docs docs-serve quick-start logs rebuild lean-check-duplicates lean-forbid-shadowing vendor-mathlib no-runtime-placeholders
+.PHONY: help build test clean demo-up demo-down demo-setup install dev validate-certs lint bench security test-all helm-install helm-upgrade docs docs-serve quick-start logs rebuild lean-check-duplicates lean-forbid-shadowing vendor-mathlib no-runtime-placeholders submodules standards-pin-check dev-standards
 
 # ---------- Cross-platform helpers ----------
 # Seconds to wait after starting containers (override with: make demo-up WAIT=10)
@@ -55,8 +55,24 @@ help:
 	@$(ECHOOK) "  make install-standard - CLI + Rust workspace"
 	@$(ECHOOK) "  make install-full    - Full install (all Python/Node deps)"
 	@$(ECHOOK) "  make validate-certs  - Validate all CERT-V1 certificates"
+	@$(ECHOOK) "  make submodules      - Init/update external standards submodules"
+	@$(ECHOOK) "  make standards-pin-check - Verify submodule tags match versions.json"
+	@$(ECHOOK) "  make dev-standards   - submodules + standards-pin-check"
 	@$(ECHOOK) "  make lint            - Run linting on all code"
 	@$(ECHOOK) ""
+
+# ---------- External standards submodules ----------
+submodules:
+	@$(ECHOOK) "Initializing external standards submodules..."
+	git submodule update --init --depth 1 external/CERT-V1 external/TRACE-REPLAY-KIT
+	@$(ECHOOK) "Submodules ready (run make standards-pin-check to verify tags)"
+
+standards-pin-check:
+	@$(ECHOOK) "Checking external standards pin drift..."
+	python tools/standards/check_pins.py
+
+dev-standards: submodules standards-pin-check
+	@$(ECHOOK) "External standards ready for local development"
 
 # ---------- Development ----------
 dev:

--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ Full PCS documentation lives at [docs/pcs/README.md](docs/pcs/README.md).
 ### Option 1 — Install script (recommended)
 
 ```bash
-git clone https://github.com/SentinelOps-CI/provability-fabric
+git clone --recurse-submodules https://github.com/SentinelOps-CI/provability-fabric
 cd provability-fabric
+make dev-standards   # optional: verify CERT-V1 + TRACE-REPLAY-KIT pins
 
 # Linux / macOS
 ./scripts/install.sh
@@ -183,8 +184,9 @@ mkdocs serve --dev-addr=127.0.0.1:8002
 ### Option 3 — Build the CLI from source
 
 ```bash
-git clone https://github.com/SentinelOps-CI/provability-fabric
+git clone --recurse-submodules https://github.com/SentinelOps-CI/provability-fabric
 cd provability-fabric
+make dev-standards   # optional: verify CERT-V1 + TRACE-REPLAY-KIT pins
 
 cd core/cli/pf
 go build -o pf .    # Windows: pf.exe
@@ -259,8 +261,9 @@ Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md) and [Co
 **Typical dev loop:**
 
 ```bash
-git clone https://github.com/SentinelOps-CI/provability-fabric
+git clone --recurse-submodules https://github.com/SentinelOps-CI/provability-fabric
 cd provability-fabric
+make dev-standards   # optional: verify CERT-V1 + TRACE-REPLAY-KIT pins
 
 cd core/cli/pf && go build -o pf . && cd ../..
 # Optional: cmd/specdoc and other Go tools as needed

--- a/external/README.md
+++ b/external/README.md
@@ -1,15 +1,36 @@
-# External dependencies (optional)
+# External dependencies (git submodules)
 
-This directory is used by `docker-compose.yml` for optional mounts:
+Pinned standards live under `external/` as git submodules. Tags are locked in
+[`tools/standards/versions.json`](../tools/standards/versions.json).
 
-- **CERT-V1** – Clone [verifiable-ai-ci/CERT-V1](https://github.com/verifiable-ai-ci/CERT-V1) into `CERT-V1/` for evidence-service schema and verifiers.
-- **TRACE-REPLAY-KIT** – Clone [verifiable-ai-ci/TRACE-REPLAY-KIT](https://github.com/verifiable-ai-ci/TRACE-REPLAY-KIT) into `TRACE-REPLAY-KIT/` for the replay-service runner.
+| Submodule | Repository | Purpose |
+|-----------|------------|---------|
+| `CERT-V1/` | [verifiable-ai-ci/CERT-V1](https://github.com/verifiable-ai-ci/CERT-V1) | CERT-V1 JSON schema and validation |
+| `TRACE-REPLAY-KIT/` | [verifiable-ai-ci/TRACE-REPLAY-KIT](https://github.com/verifiable-ai-ci/TRACE-REPLAY-KIT) | Deterministic trace replay runner |
 
-If these directories are missing, Docker Compose will create empty mount points and the platform will start; full evidence and replay features may require the real content.
-
-Example setup:
+## Fresh clone
 
 ```bash
-git clone --depth 1 https://github.com/verifiable-ai-ci/CERT-V1.git CERT-V1
-git clone --depth 1 https://github.com/verifiable-ai-ci/TRACE-REPLAY-KIT.git TRACE-REPLAY-KIT
+git clone --recurse-submodules https://github.com/SentinelOps-CI/provability-fabric.git
+cd provability-fabric
+make dev-standards
 ```
+
+If you already cloned without submodules:
+
+```bash
+make submodules
+make standards-pin-check
+```
+
+## Docker Compose
+
+`docker-compose.yml` mounts these directories for evidence-service and replay-service.
+If submodules are missing, Compose creates empty mount points; run `make submodules`
+before relying on CERT validation or deep replay.
+
+## Windows / Docker
+
+For local Windows development without native submodule paths, mount this repo into
+Docker Compose and run sidecar or cert tests inside the Linux container where
+`external/CERT-V1` is available.

--- a/tools/standards/check_pins.py
+++ b/tools/standards/check_pins.py
@@ -51,6 +51,19 @@ def get_remote_url(path: str) -> str | None:
         return None
 
 
+def get_head_commit(path: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", path, "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
 def main() -> int:
     versions_path = os.path.join("tools", "standards", "versions.json")
     if not os.path.exists(versions_path):
@@ -60,8 +73,11 @@ def main() -> int:
     with open(versions_path, "r", encoding="utf-8") as f:
         versions = json.load(f)
 
+    pin_commits = versions.get("pins", {})
     failures = 0
     for name, expected_tag in versions.items():
+        if name == "pins":
+            continue
         repo_path = REPO_MAP.get(name)
         if not repo_path:
             print(f"[WARN] Unknown repo mapping for {name}; skipping")
@@ -74,6 +90,21 @@ def main() -> int:
 
         remote = get_remote_url(repo_path) or "(unknown)"
         tag = get_exact_tag(repo_path)
+        expected_commit = pin_commits.get(name)
+
+        if tag == expected_tag:
+            ok_msg = f"[OK] {name}: pinned to {tag} (remote={remote})"
+            print(ok_msg)
+            continue
+
+        head = get_head_commit(repo_path)
+        if expected_commit and head and head.startswith(expected_commit):
+            ok_msg = (
+                f"[OK] {name}: commit {head[:12]} matches pin "
+                f"(tag {expected_tag} not checked out; remote={remote})"
+            )
+            print(ok_msg)
+            continue
 
         if tag is None:
             msg = (
@@ -82,6 +113,8 @@ def main() -> int:
             )
             print(msg)
             print(f"       Expected tag: {expected_tag}.")
+            if expected_commit:
+                print(f"       Expected commit prefix: {expected_commit}.")
             fix_str = (
                 "       Fix: git -C {p} fetch --tags && git -C {p} " "checkout {tag}"
             )
@@ -89,25 +122,21 @@ def main() -> int:
             failures += 1
             continue
 
-        if tag != expected_tag:
-            msg = f"[FAIL] {name}: tag mismatch at {repo_path} " f"(remote={remote})."
-            print(msg)
-            print(f"       Current: {tag}")
-            print(f"       Expected: {expected_tag}")
-            fix_str = (
-                "       Fix: git -C {p} fetch --tags && git -C {p} " "checkout {tag}"
-            )
-            print(fix_str.format(p=repo_path, tag=expected_tag))
-            failures += 1
-        else:
-            ok_msg = f"[OK] {name}: pinned to {tag} (remote={remote})"
-            print(ok_msg)
+        msg = f"[FAIL] {name}: tag mismatch at {repo_path} " f"(remote={remote})."
+        print(msg)
+        print(f"       Current: {tag}")
+        print(f"       Expected: {expected_tag}")
+        fix_str = (
+            "       Fix: git -C {p} fetch --tags && git -C {p} " "checkout {tag}"
+        )
+        print(fix_str.format(p=repo_path, tag=expected_tag))
+        failures += 1
 
     if failures:
-        print(f"\n❌ Standards pin check failed: {failures} issue(s)")
+        print(f"\nStandards pin check failed: {failures} issue(s)")
         return 1
 
-    print("\n✅ Standards pin check passed")
+    print("\nStandards pin check passed")
     return 0
 
 

--- a/tools/standards/versions.json
+++ b/tools/standards/versions.json
@@ -1,6 +1,8 @@
 {
   "CERT-V1": "v1.0.0",
-  "TRACE-REPLAY-KIT": "v1.0.0"
+  "TRACE-REPLAY-KIT": "v1.0.0",
+  "pins": {
+    "CERT-V1": "61ad3e5e29ffea3c4090f9862862b6e007024362",
+    "TRACE-REPLAY-KIT": "957630f1ab8c00031c5f56d32e610a9f8baf69b6"
+  }
 }
-
-


### PR DESCRIPTION
## Summary

- Add `.gitmodules` for CERT-V1 and TRACE-REPLAY-KIT with branch pins
- Add Makefile targets: `submodules`, `standards-pin-check`, `dev-standards`
- Extend `tools/standards/versions.json` and `check_pins.py` for submodule tag verification
- Document clone/setup in README, CONTRIBUTING, and `external/README.md`
- Trigger standards-pin workflow on `.gitmodules` and Makefile changes

## Test plan

- [ ] `make dev-standards` on fresh clone
- [ ] `make standards-pin-check` passes with initialized submodules
- [ ] standards-pin CI workflow runs on this PR

Stack: PR 1/7 (base: `main`)