### PR TITLE
Evidence v0.2: TRACE-REPLAY-KIT trace import adapter

### DIFF
--- a/core/cli/pf/evidence_commands.go
+++ b/core/cli/pf/evidence_commands.go
@@ -15,12 +15,46 @@ import (
 func evidenceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "evidence",
-		Short: "Evidence v0.1 bundle pack, validate, and replay",
+		Short: "Evidence v0.1 bundle pack, validate, trace import, and replay",
 		Long:  "Pack, validate, and replay Evidence v0.1 JSON bundles (distinct from PCS EvidenceBundle.v0 and so bundle pack tar archives).",
 	}
 	cmd.AddCommand(evidenceBundleCmd())
 	cmd.AddCommand(evidenceValidateCmd())
+	cmd.AddCommand(evidenceTraceCmd())
 	cmd.AddCommand(evidenceReplayCmd())
+	return cmd
+}
+
+func evidenceTraceCmd() *cobra.Command {
+	var kitPath, outPath, traceID string
+	cmd := &cobra.Command{
+		Use:   "trace",
+		Short: "Execution trace operations",
+	}
+	importCmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import TRACE-REPLAY-KIT trace JSON into v0.1 execution-trace",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if kitPath == "" || outPath == "" {
+				return fmt.Errorf("--kit-trace and --out are required")
+			}
+			trace, err := evidence.ImportKITTrace(kitPath, traceID)
+			if err != nil {
+				return err
+			}
+			if err := evidence.WriteExecutionTrace(outPath, trace); err != nil {
+				return err
+			}
+			fmt.Printf("Wrote execution trace %s (digest %s)\n", outPath, trace.TraceDigest)
+			return nil
+		},
+	}
+	importCmd.Flags().StringVar(&kitPath, "kit-trace", "", "Path to TRACE-REPLAY-KIT trace.json")
+	importCmd.Flags().StringVar(&outPath, "out", "", "Output execution-trace.json path")
+	importCmd.Flags().StringVar(&traceID, "trace-id", "", "Optional trace_id (default from kit name)")
+	_ = importCmd.MarkFlagRequired("kit-trace")
+	_ = importCmd.MarkFlagRequired("out")
+	cmd.AddCommand(importCmd)
 	return cmd
 }
 

--- a/core/evidence/trace_adapter.go
+++ b/core/evidence/trace_adapter.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+package evidence
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// TraceEvent is one step in a v0.1 execution trace.
+type TraceEvent struct {
+	Seq  int            `json:"seq"`
+	Kind string         `json:"kind"`
+	Meta map[string]any `json:",inline"`
+}
+
+// ExecutionTrace is the v0.1 execution-trace artifact shape.
+type ExecutionTrace struct {
+	SchemaVersion string       `json:"schema_version"`
+	TraceID       string       `json:"trace_id"`
+	Events        []TraceEvent `json:"events"`
+	TraceDigest   string       `json:"trace_digest"`
+}
+
+type kitSimpleTrace struct {
+	Name  string `json:"name"`
+	Steps []struct {
+		Op   string         `json:"op"`
+		Tool string         `json:"tool,omitempty"`
+		Args map[string]any `json:"args,omitempty"`
+	} `json:"steps"`
+}
+
+type kitEventTrace struct {
+	Metadata map[string]any `json:"metadata"`
+	Events   []struct {
+		ID      string         `json:"id"`
+		Type    string         `json:"type"`
+		Payload map[string]any `json:"payload,omitempty"`
+	} `json:"events"`
+}
+
+// ImportKITTrace converts a TRACE-REPLAY-KIT trace JSON file into a v0.1 execution trace.
+func ImportKITTrace(kitPath string, traceID string) (ExecutionTrace, error) {
+	data, err := os.ReadFile(kitPath)
+	if err != nil {
+		return ExecutionTrace{}, fmt.Errorf("read kit trace: %w", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return ExecutionTrace{}, fmt.Errorf("parse kit trace: %w", err)
+	}
+
+	events, idHint, err := mapKITToEvents(data)
+	if err != nil {
+		return ExecutionTrace{}, err
+	}
+	if len(events) == 0 {
+		return ExecutionTrace{}, fmt.Errorf("kit trace produced no events")
+	}
+	if traceID == "" {
+		traceID = idHint
+		if traceID == "" {
+			traceID = "kit-import"
+		}
+	}
+
+	trace := ExecutionTrace{
+		SchemaVersion: SchemaVersion,
+		TraceID:       traceID,
+		Events:        events,
+	}
+	digest, err := CanonicalJSONDigest(trace, "trace_digest")
+	if err != nil {
+		return ExecutionTrace{}, err
+	}
+	trace.TraceDigest = digest
+	return trace, nil
+}
+
+func mapKITToEvents(data []byte) ([]TraceEvent, string, error) {
+	var simple kitSimpleTrace
+	if err := json.Unmarshal(data, &simple); err == nil && len(simple.Steps) > 0 {
+		events := make([]TraceEvent, 0, len(simple.Steps))
+		for i, step := range simple.Steps {
+			kind := step.Op
+			if step.Tool != "" {
+				kind = step.Op + ":" + step.Tool
+			}
+			ev := TraceEvent{Seq: i, Kind: kind}
+			if len(step.Args) > 0 {
+				ev.Meta = map[string]any{"args": step.Args}
+			}
+			events = append(events, ev)
+		}
+		return events, simple.Name, nil
+	}
+
+	var eventTrace kitEventTrace
+	if err := json.Unmarshal(data, &eventTrace); err != nil {
+		return nil, "", fmt.Errorf("unsupported kit trace format")
+	}
+	if len(eventTrace.Events) == 0 {
+		return nil, "", fmt.Errorf("kit trace missing steps or events")
+	}
+	events := make([]TraceEvent, 0, len(eventTrace.Events))
+	nameHint := ""
+	if eventTrace.Metadata != nil {
+		if sys, ok := eventTrace.Metadata["system_info"].(map[string]any); ok {
+			if n, ok := sys["name"].(string); ok {
+				nameHint = n
+			}
+		}
+	}
+	for i, ev := range eventTrace.Events {
+		kind := ev.Type
+		if kind == "" {
+			kind = "event"
+		}
+		item := TraceEvent{Seq: i, Kind: kind}
+		if ev.ID != "" {
+			item.Meta = map[string]any{"id": ev.ID}
+		}
+		if len(ev.Payload) > 0 {
+			if item.Meta == nil {
+				item.Meta = map[string]any{}
+			}
+			item.Meta["payload"] = ev.Payload
+		}
+		events = append(events, item)
+	}
+	return events, nameHint, nil
+}
+
+// WriteExecutionTrace writes an execution trace JSON file.
+func WriteExecutionTrace(path string, trace ExecutionTrace) error {
+	out, err := json.MarshalIndent(trace, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	return os.WriteFile(path, out, 0644)
+}
+
+// MarshalTraceEvent implements custom JSON for inline meta fields.
+func (e TraceEvent) MarshalJSON() ([]byte, error) {
+	m := map[string]any{"seq": e.Seq, "kind": e.Kind}
+	for k, v := range e.Meta {
+		if k == "seq" || k == "kind" {
+			continue
+		}
+		m[k] = v
+	}
+	return json.Marshal(m)
+}
+
+func (e *TraceEvent) UnmarshalJSON(data []byte) error {
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	seqF, ok := raw["seq"].(float64)
+	if !ok {
+		return fmt.Errorf("event missing seq")
+	}
+	kind, ok := raw["kind"].(string)
+	if !ok || strings.TrimSpace(kind) == "" {
+		return fmt.Errorf("event missing kind")
+	}
+	e.Seq = int(seqF)
+	e.Kind = kind
+	delete(raw, "seq")
+	delete(raw, "kind")
+	if len(raw) > 0 {
+		e.Meta = raw
+	}
+	return nil
+}

--- a/core/evidence/trace_adapter_test.go
+++ b/core/evidence/trace_adapter_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+package evidence
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestImportKITSimpleTrace(t *testing.T) {
+	root := repoRoot(t)
+	kitPath := filepath.Join(root, "tests", "replay", "bundles", "simple", "trace.json")
+	trace, err := ImportKITTrace(kitPath, "simple-import")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if trace.TraceID != "simple-import" {
+		t.Fatalf("trace_id: %s", trace.TraceID)
+	}
+	if len(trace.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(trace.Events))
+	}
+	if trace.Events[0].Kind != "call:Echo" {
+		t.Fatalf("first kind: %s", trace.Events[0].Kind)
+	}
+	expected, err := CanonicalJSONDigest(trace, "trace_digest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trace.TraceDigest != expected {
+		t.Fatalf("digest mismatch")
+	}
+}
+
+func TestImportKITTraceRoundTripValidate(t *testing.T) {
+	root := repoRoot(t)
+	kitPath := filepath.Join(root, "tests", "replay", "bundles", "simple", "trace.json")
+	trace, err := ImportKITTrace(kitPath, "")
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "execution-trace.json")
+	if err := WriteExecutionTrace(out, trace); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schemaPath := filepath.Join(root, "specs", "evidence", "v0.1", "schemas", "execution-trace.schema.json")
+	if err := validateAgainstSchema(schemaPath, body); err != nil {
+		t.Fatalf("schema validate: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := CanonicalJSONDigest(parsed, "trace_digest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digest != trace.TraceDigest {
+		t.Fatalf("round-trip digest mismatch")
+	}
+}

--- a/docs/specs/evidence-compatibility.md
+++ b/docs/specs/evidence-compatibility.md
@@ -13,6 +13,7 @@ Evidence v0.1 is a distinct JSON bundle lane. This matrix maps existing platform
 
 | Platform artifact | v0.1 mapping | Notes |
 |-------------------|--------------|-------|
+| KIT `trace.json` (steps or events) | Import via `pf evidence trace import --kit-trace … --out execution-trace.json` | Produces v0.1 `execution-trace` artifact |
 | Trace JSON / replay bundle | `execution-trace` role artifact | Referenced by digest; replay CLI checks trace self-digest |
 | `so trace run` | Unchanged | v0.1 replay wraps bundle checks only |
 

--- a/tests/evidence_trace/test_trace_import.py
+++ b/tests/evidence_trace/test_trace_import.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Evidence trace import CLI tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PF = REPO / "core" / "cli" / "pf" / "pf"
+KIT_TRACE = REPO / "tests" / "replay" / "bundles" / "simple" / "trace.json"
+SCHEMA = REPO / "specs" / "evidence" / "v0.1" / "schemas" / "execution-trace.schema.json"
+
+
+@pytest.fixture(scope="module")
+def pf_bin() -> Path:
+    if not PF.exists() and not (REPO / "core" / "cli" / "pf" / "pf.exe").exists():
+        subprocess.run(["go", "build", "-o", "pf", "."], cwd=REPO / "core" / "cli" / "pf", check=True)
+    for candidate in (PF, REPO / "core" / "cli" / "pf" / "pf.exe"):
+        if candidate.exists():
+            return candidate
+    raise RuntimeError("pf binary not found")
+
+
+def test_trace_import_validates_strict(pf_bin: Path, tmp_path: Path) -> None:
+    out = tmp_path / "execution-trace.json"
+    proc = subprocess.run(
+        [
+            str(pf_bin),
+            "evidence",
+            "trace",
+            "import",
+            "--kit-trace",
+            str(KIT_TRACE),
+            "--out",
+            str(out),
+            "--trace-id",
+            "pytest-import",
+        ],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    data = json.loads(out.read_text(encoding="utf-8"))
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    jsonschema.validate(data, schema)
+    assert data["trace_id"] == "pytest-import"
+    assert len(data["events"]) >= 1


### PR DESCRIPTION
## Summary

- Add `core/evidence/trace_adapter.go` to import KIT `trace.json` into v0.1 execution-trace artifacts
- Add `pf evidence trace import --kit-trace --out` CLI subcommand
- Add unit tests and `tests/evidence_trace/test_trace_import.py`
- Document KIT import row in compatibility matrix

## Test plan

- [ ] `go test ./...` in `core/evidence`
- [ ] `pytest tests/evidence_trace -q`
- [ ] Manual: `pf evidence trace import` against v0.2 fixture kit trace

Stack: PR 2/7 (base: `evidence-v02/submodules`)