### PR TITLE
Evidence v0.2: schema and replay_context validation

### DIFF
--- a/core/cli/pf/evidence_commands.go
+++ b/core/cli/pf/evidence_commands.go
@@ -64,11 +64,11 @@ func evidenceBundleCmd() *cobra.Command {
 
 	bundle := &cobra.Command{
 		Use:   "bundle",
-		Short: "Evidence v0.1 bundle operations",
+		Short: "Evidence v0.1/v0.2 bundle operations",
 	}
 	pack := &cobra.Command{
 		Use:   "pack",
-		Short: "Pack an Evidence v0.1 bundle from a manifest",
+		Short: "Pack an Evidence bundle from a manifest",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if manifestPath == "" || outPath == "" {
 				return fmt.Errorf("--manifest and --out are required")
@@ -106,7 +106,7 @@ func evidenceValidateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "validate [bundle]",
-		Short: "Validate an Evidence v0.1 bundle",
+		Short: "Validate an Evidence v0.1 or v0.2 bundle",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			report, err := evidence.ValidateBundle(evidence.ValidateOptions{

--- a/core/evidence/bundle.go
+++ b/core/evidence/bundle.go
@@ -19,14 +19,22 @@ type ArtifactRef struct {
 	Digest    string `json:"digest"`
 }
 
-// EvidenceBundle is the v0.1 bundle manifest.
+// ReplayContext describes executable replay inputs for v0.2 bundles.
+type ReplayContext struct {
+	KitTracePath   string `json:"kit_trace_path,omitempty"`
+	FixturesPath   string `json:"fixtures_path,omitempty"`
+	LowViewOracle  bool   `json:"low_view_oracle,omitempty"`
+}
+
+// EvidenceBundle is the v0.1/v0.2 bundle manifest.
 type EvidenceBundle struct {
-	BundleID      string        `json:"bundle_id"`
-	SchemaVersion string        `json:"schema_version"`
-	CreatedAt     string        `json:"created_at"`
-	Producer      string        `json:"producer"`
-	Artifacts     []ArtifactRef `json:"artifacts"`
-	BundleDigest  string        `json:"bundle_digest"`
+	BundleID      string         `json:"bundle_id"`
+	SchemaVersion string         `json:"schema_version"`
+	CreatedAt     string         `json:"created_at"`
+	Producer      string         `json:"producer"`
+	Artifacts     []ArtifactRef  `json:"artifacts"`
+	ReplayContext *ReplayContext `json:"replay_context,omitempty"`
+	BundleDigest  string         `json:"bundle_digest"`
 }
 
 // PackManifest describes inputs for bundle pack.
@@ -35,6 +43,7 @@ type PackManifest struct {
 	BundleID      string `json:"bundle_id"`
 	Producer      string `json:"producer"`
 	CreatedAt     string `json:"created_at,omitempty"`
+	ReplayContext *ReplayContext `json:"replay_context,omitempty"`
 	Artifacts     []struct {
 		Role      string `json:"role"`
 		Path      string `json:"path"`
@@ -70,7 +79,7 @@ func Pack(opts PackOptions) (*EvidenceBundle, error) {
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return nil, fmt.Errorf("parse manifest: %w", err)
 	}
-	if manifest.SchemaVersion != SchemaVersion {
+	if manifest.SchemaVersion != SchemaVersion && manifest.SchemaVersion != SchemaVersionV02 {
 		return nil, fmt.Errorf("unsupported schema_version %q", manifest.SchemaVersion)
 	}
 	if manifest.BundleID == "" {
@@ -113,9 +122,10 @@ func Pack(opts PackOptions) (*EvidenceBundle, error) {
 
 	bundle := EvidenceBundle{
 		BundleID:      manifest.BundleID,
-		SchemaVersion: SchemaVersion,
+		SchemaVersion: manifest.SchemaVersion,
 		CreatedAt:     manifest.CreatedAt,
 		Producer:      manifest.Producer,
+		ReplayContext: manifest.ReplayContext,
 		Artifacts:     refs,
 	}
 	digest, err := bundleDigest(bundle)

--- a/core/evidence/validator.go
+++ b/core/evidence/validator.go
@@ -74,7 +74,8 @@ func ValidateBundle(opts ValidateOptions) (*ValidationReport, error) {
 		return report, fmt.Errorf("invalid bundle JSON: %w", err)
 	}
 
-	schemaPath := filepath.Join(opts.RepoRoot, "specs", "evidence", "v0.1", "schemas", "evidence-bundle.schema.json")
+	schemaDir := filepath.Join(opts.RepoRoot, "specs", "evidence", schemaVersionDir(bundle.SchemaVersion), "schemas")
+	schemaPath := filepath.Join(schemaDir, "evidence-bundle.schema.json")
 	if err := validateAgainstSchema(schemaPath, data); err != nil {
 		report.Status = "fail"
 		report.Errors = append(report.Errors, err.Error())
@@ -83,11 +84,19 @@ func ValidateBundle(opts ValidateOptions) (*ValidationReport, error) {
 		}
 	}
 
-	if bundle.SchemaVersion != SchemaVersion {
+	if bundle.SchemaVersion != SchemaVersion && bundle.SchemaVersion != SchemaVersionV02 {
 		err := fmt.Errorf("unsupported schema_version %q", bundle.SchemaVersion)
 		report.Status = "fail"
 		report.Errors = append(report.Errors, err.Error())
 		if opts.Strict {
+			return report, err
+		}
+	}
+
+	if opts.Strict && bundle.ReplayContext != nil {
+		if err := validateReplayContext(opts.BaseDir, bundle.ReplayContext); err != nil {
+			report.Status = "fail"
+			report.Errors = append(report.Errors, err.Error())
 			return report, err
 		}
 	}
@@ -138,7 +147,7 @@ func ValidateBundle(opts ValidateOptions) (*ValidationReport, error) {
 		}
 
 		if opts.Strict {
-			if err := validateRoleArtifact(opts.RepoRoot, ref.Role, artifactPath); err != nil {
+			if err := validateRoleArtifact(opts.RepoRoot, bundle.SchemaVersion, ref.Role, artifactPath); err != nil {
 				report.Status = "fail"
 				report.Errors = append(report.Errors, err.Error())
 				return report, err
@@ -152,7 +161,7 @@ func ValidateBundle(opts ValidateOptions) (*ValidationReport, error) {
 	return report, nil
 }
 
-func validateRoleArtifact(repoRoot, role, artifactPath string) error {
+func validateRoleArtifact(repoRoot, schemaVersion, role, artifactPath string) error {
 	schemaName, ok := roleSchemaName(role)
 	if !ok {
 		return nil
@@ -161,8 +170,34 @@ func validateRoleArtifact(repoRoot, role, artifactPath string) error {
 	if err != nil {
 		return err
 	}
+	// Role artifact schemas are shared across v0.1 and v0.2 bundle versions.
 	schemaPath := filepath.Join(repoRoot, "specs", "evidence", "v0.1", "schemas", schemaName)
 	return validateAgainstSchema(schemaPath, body)
+}
+
+func schemaVersionDir(version string) string {
+	if version == SchemaVersionV02 {
+		return "v0.2"
+	}
+	return "v0.1"
+}
+
+func validateReplayContext(baseDir string, ctx *ReplayContext) error {
+	if ctx.KitTracePath != "" {
+		p := filepath.Join(baseDir, filepath.FromSlash(ctx.KitTracePath))
+		if _, err := os.Stat(p); err != nil {
+			return fmt.Errorf("replay_context.kit_trace_path missing: %w", err)
+		}
+	}
+	if ctx.FixturesPath != "" {
+		p := filepath.Join(baseDir, filepath.FromSlash(ctx.FixturesPath))
+		if st, err := os.Stat(p); err != nil {
+			return fmt.Errorf("replay_context.fixtures_path missing: %w", err)
+		} else if !st.IsDir() {
+			return fmt.Errorf("replay_context.fixtures_path is not a directory: %s", ctx.FixturesPath)
+		}
+	}
+	return nil
 }
 
 func roleSchemaName(role string) (string, bool) {

--- a/specs/evidence/v0.2/examples/valid/artifacts/attestation.json
+++ b/specs/evidence/v0.2/examples/valid/artifacts/attestation.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "0.1",
+  "attestation_id": "attest-basic-001",
+  "attestor": "sidecar-watcher/demo",
+  "signed_claim_ref": {
+    "role": "proof",
+    "path": "artifacts/proof.json",
+    "media_type": "application/vnd.provability-fabric.evidence.proof+json",
+    "digest": "sha256:3c1435ff573801180594e2f0a2074b0e4d370bb6d84e9c4629a4b96e974fa5e9"
+  },
+  "signature": "demo-signature-placeholder"
+}

--- a/specs/evidence/v0.2/examples/valid/artifacts/claim.json
+++ b/specs/evidence/v0.2/examples/valid/artifacts/claim.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "0.1",
+  "claim_id": "claim-basic-001",
+  "statement": "Agent execution stayed within declared policy bounds for the demo session.",
+  "subject": {
+    "agent_id": "demo-agent",
+    "session_id": "sess-001"
+  }
+}

--- a/specs/evidence/v0.2/examples/valid/artifacts/execution-trace.json
+++ b/specs/evidence/v0.2/examples/valid/artifacts/execution-trace.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "0.1",
+  "trace_id": "deep-replay-001",
+  "events": [
+    {
+      "id": "event_001",
+      "kind": "function_call",
+      "payload": {
+        "args": [
+          1,
+          2
+        ],
+        "function": "add_numbers",
+        "hash": "sha256:5d41402abc4b2a76b9719d911017c592"
+      },
+      "seq": 0
+    }
+  ],
+  "trace_digest": "sha256:348b839df12bd87697912fdcb4a7c35ea3b1da9b8c8569204a7e01c90d4ee209"
+}

--- a/specs/evidence/v0.2/examples/valid/artifacts/proof.json
+++ b/specs/evidence/v0.2/examples/valid/artifacts/proof.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "0.1",
+  "proof_id": "proof-basic-001",
+  "proof_system": "lean4",
+  "artifact_refs": [
+    {
+      "role": "claim",
+      "path": "artifacts/claim.json",
+      "media_type": "application/vnd.provability-fabric.evidence.claim+json",
+      "digest": "sha256:09b99e794ee3a38346bc692ddab77c5b9b95d7c82526d6b19b176f64f3e17f3e"
+    }
+  ],
+  "proof_digest": "sha256:ac5d2e7a13046cdae7a22c4b7a00abdbd6302c2514d5f6607a17234a2c2fdec1"
+}

--- a/specs/evidence/v0.2/examples/valid/deep-replay-bundle.json
+++ b/specs/evidence/v0.2/examples/valid/deep-replay-bundle.json
@@ -1,0 +1,38 @@
+{
+  "bundle_id": "deep-replay-bundle",
+  "schema_version": "0.2",
+  "created_at": "2025-06-14T12:00:00Z",
+  "producer": "pf-evidence/v0.2",
+  "artifacts": [
+    {
+      "role": "claim",
+      "path": "artifacts/claim.json",
+      "media_type": "application/vnd.provability-fabric.evidence.claim+json",
+      "digest": "sha256:09b99e794ee3a38346bc692ddab77c5b9b95d7c82526d6b19b176f64f3e17f3e"
+    },
+    {
+      "role": "proof",
+      "path": "artifacts/proof.json",
+      "media_type": "application/vnd.provability-fabric.evidence.proof+json",
+      "digest": "sha256:c321e0bfcc750ca2bc7ab7a38ae7b1d97c7af423d80d49cbb3e0a62921a1f3e2"
+    },
+    {
+      "role": "attestation",
+      "path": "artifacts/attestation.json",
+      "media_type": "application/vnd.provability-fabric.evidence.attestation+json",
+      "digest": "sha256:94f7446165c3d48821d4ec658617ada293c4f78f56ba0794096329745f83f174"
+    },
+    {
+      "role": "execution-trace",
+      "path": "artifacts/execution-trace.json",
+      "media_type": "application/vnd.provability-fabric.evidence.execution-trace+json",
+      "digest": "sha256:aff1f74ac2eee62de1170c25de7bfa233285e8698c5f3d4b4c45d1b7bca26b3c"
+    }
+  ],
+  "replay_context": {
+    "kit_trace_path": "kit/trace.json",
+    "fixtures_path": "kit/fixtures",
+    "low_view_oracle": true
+  },
+  "bundle_digest": "sha256:51efd84fcce1e575711add87d596fa42d54c90c57e825f6de9ca7eae14e0b02e"
+}

--- a/specs/evidence/v0.2/examples/valid/kit/fixtures/env.json
+++ b/specs/evidence/v0.2/examples/valid/kit/fixtures/env.json
@@ -1,0 +1,9 @@
+{
+  "locale": "en_US.UTF-8",
+  "timezone": "UTC",
+  "seed": 42,
+  "versions": {
+    "python": "3.11.0",
+    "system_lib": "1.0.0"
+  }
+}

--- a/specs/evidence/v0.2/examples/valid/kit/trace.json
+++ b/specs/evidence/v0.2/examples/valid/kit/trace.json
@@ -1,0 +1,26 @@
+{
+  "metadata": {
+    "version": "1.0.0",
+    "created_at": "2024-01-01T00:00:00Z",
+    "system_info": {
+      "name": "simple_call_test",
+      "version": "1.0.0"
+    }
+  },
+  "events": [
+    {
+      "id": "event_001",
+      "timestamp": "2024-01-01T00:00:00.000Z",
+      "type": "function_call",
+      "payload": {
+        "function": "add_numbers",
+        "args": [1, 2],
+        "hash": "sha256:5d41402abc4b2a76b9719d911017c592"
+      },
+      "context": {
+        "thread_id": "main",
+        "call_stack": ["main", "add_numbers"]
+      }
+    }
+  ]
+}

--- a/specs/evidence/v0.2/examples/valid/manifest.json
+++ b/specs/evidence/v0.2/examples/valid/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "0.2",
+  "bundle_id": "deep-replay-bundle",
+  "producer": "pf-evidence/v0.2",
+  "created_at": "2025-06-14T12:00:00Z",
+  "replay_context": {
+    "kit_trace_path": "kit/trace.json",
+    "fixtures_path": "kit/fixtures",
+    "low_view_oracle": true
+  },
+  "artifacts": [
+    { "role": "claim", "path": "artifacts/claim.json" },
+    { "role": "proof", "path": "artifacts/proof.json" },
+    { "role": "attestation", "path": "artifacts/attestation.json" },
+    { "role": "execution-trace", "path": "artifacts/execution-trace.json" }
+  ]
+}

--- a/specs/evidence/v0.2/schemas/evidence-bundle.schema.json
+++ b/specs/evidence/v0.2/schemas/evidence-bundle.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://provability-fabric.org/schemas/evidence/v0.2/evidence-bundle.schema.json",
+  "title": "EvidenceBundleV02",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["bundle_id", "schema_version", "artifacts", "bundle_digest", "created_at", "producer"],
+  "properties": {
+    "bundle_id": { "type": "string", "minLength": 1 },
+    "schema_version": { "const": "0.2" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "producer": { "type": "string", "minLength": 1 },
+    "replay_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kit_trace_path": { "type": "string", "minLength": 1 },
+        "fixtures_path": { "type": "string", "minLength": 1 },
+        "low_view_oracle": { "type": "boolean" }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/artifact_ref" }
+    },
+    "bundle_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  },
+  "$defs": {
+    "artifact_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "path", "media_type", "digest"],
+      "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "media_type": { "type": "string", "minLength": 1 },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Publish `specs/evidence/v0.2/schemas/evidence-bundle.schema.json` and valid fixtures
- Extend `bundle.go` and `validator.go` for v0.2 `replay_context` fields
- Update CLI help for v0.1/v0.2 bundle pack and validate

## Test plan

- [ ] `go test ./...` in `core/evidence`
- [ ] `pytest tests/evidence_schema tests/evidence_validation -q`
- [ ] Validate v0.2 fixture bundle with `pf evidence validate --strict`

Stack: PR 3/7 (base: `evidence-v02/trace-adapter`)