### PR TITLE
Evidence v0.2: deep replay execution via KIT

### DIFF
--- a/core/cli/pf/evidence_commands.go
+++ b/core/cli/pf/evidence_commands.go
@@ -15,8 +15,8 @@ import (
 func evidenceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "evidence",
-		Short: "Evidence v0.1 bundle pack, validate, trace import, and replay",
-		Long:  "Pack, validate, and replay Evidence v0.1 JSON bundles (distinct from PCS EvidenceBundle.v0 and so bundle pack tar archives).",
+		Short: "Evidence v0.1/v0.2 bundle pack, validate, trace import, and replay",
+		Long:  "Pack, validate, and replay Evidence v0.1/v0.2 JSON bundles (distinct from PCS EvidenceBundle.v0 and so bundle pack tar archives).",
 	}
 	cmd.AddCommand(evidenceBundleCmd())
 	cmd.AddCommand(evidenceValidateCmd())
@@ -148,27 +148,37 @@ func evidenceValidateCmd() *cobra.Command {
 }
 
 func evidenceReplayCmd() *cobra.Command {
-	var outPath string
-	var jsonOut bool
+	var bundlePath, outPath, fixturesDir, outDir, baseDir string
+	var jsonOut, execute, lowView bool
 
 	cmd := &cobra.Command{
 		Use:   "replay",
-		Short: "Verify replay preconditions for an Evidence v0.1 bundle",
+		Short: "Verify replay preconditions and optionally execute KIT replay",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			bundlePath, _ := cmd.Flags().GetString("bundle")
 			if bundlePath == "" {
 				return fmt.Errorf("--bundle is required")
 			}
 			report, err := evidence.ReplayBundle(evidence.ReplayOptions{
-				BundlePath: bundlePath,
-				OutPath:    outPath,
+				BundlePath:     bundlePath,
+				OutPath:        outPath,
+				BaseDir:        baseDir,
+				Execute:        execute,
+				FixturesDir:    fixturesDir,
+				OutDir:         outDir,
+				LowViewCompare: lowView,
 			})
 			if jsonOut {
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
 				_ = enc.Encode(report)
 			} else {
-				fmt.Printf("status: %s trace_found=%v\n", report.Status, report.TraceFound)
+				fmt.Printf("status: %s static=%s trace_found=%v\n", report.Status, report.StaticStatus, report.TraceFound)
+				if report.ExecuteStatus != "" {
+					fmt.Printf("execute: %s\n", report.ExecuteStatus)
+				}
+				if report.LowViewResult != "" {
+					fmt.Printf("low_view: %s\n", report.LowViewResult)
+				}
 				for _, msg := range report.Errors {
 					fmt.Printf("error: %s\n", msg)
 				}
@@ -176,9 +186,14 @@ func evidenceReplayCmd() *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().String("bundle", "", "Path to Evidence v0.1 bundle JSON")
+	cmd.Flags().StringVar(&bundlePath, "bundle", "", "Path to Evidence bundle JSON")
 	_ = cmd.MarkFlagRequired("bundle")
 	cmd.Flags().StringVar(&outPath, "out", "", "Write replay report JSON")
+	cmd.Flags().StringVar(&baseDir, "base-dir", "", "Directory containing bundle artifacts")
+	cmd.Flags().StringVar(&fixturesDir, "fixtures", "", "Fixtures directory for --execute")
+	cmd.Flags().StringVar(&outDir, "out-dir", "", "Output directory for KIT replay artifacts")
+	cmd.Flags().BoolVar(&execute, "execute", false, "Run TRACE-REPLAY-KIT after static checks")
+	cmd.Flags().BoolVar(&lowView, "low-view", false, "Compare low-view outputs after execute")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit replay report JSON to stdout")
 	return cmd
 }

--- a/core/evidence/kit_runner.go
+++ b/core/evidence/kit_runner.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+package evidence
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// KITRunner executes TRACE-REPLAY-KIT replay_run.py.
+type KITRunner interface {
+	Run(tracePath, fixturesPath, certOut string) (exitCode int, err error)
+	CompareLowView(outputFiles []string, minDeterminism float64) (exitCode int, err error)
+}
+
+type defaultKITRunner struct {
+	repoRoot string
+}
+
+// NewKITRunner returns a runner rooted at repoRoot (or discovered from cwd).
+func NewKITRunner(repoRoot string) (KITRunner, error) {
+	if repoRoot == "" {
+		var err error
+		repoRoot, err = FindRepoRoot(".")
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &defaultKITRunner{repoRoot: repoRoot}, nil
+}
+
+func (r *defaultKITRunner) python() string {
+	candidates := []string{"python3", "python"}
+	if runtime.GOOS == "windows" {
+		candidates = []string{"python", "py", "python3"}
+	}
+	for _, name := range candidates {
+		if _, err := exec.LookPath(name); err == nil {
+			return name
+		}
+	}
+	return "python3"
+}
+
+func (r *defaultKITRunner) runnerScript() string {
+	return filepath.Join(r.repoRoot, "external", "TRACE-REPLAY-KIT", "runner", "replay_run.py")
+}
+
+func (r *defaultKITRunner) lowViewOracle() string {
+	return filepath.Join(r.repoRoot, "external", "TRACE-REPLAY-KIT", "oracles", "lowview_equal.py")
+}
+
+// RunKITTrace executes the KIT runner and returns process exit code.
+func RunKITTrace(tracePath, fixturesPath, outDir, repoRoot string) (int, error) {
+	runner, err := NewKITRunner(repoRoot)
+	if err != nil {
+		return 1, err
+	}
+	certOut := filepath.Join(outDir, "replay.cert.json")
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		return 1, err
+	}
+	return runner.Run(tracePath, fixturesPath, certOut)
+}
+
+func (r *defaultKITRunner) Run(tracePath, fixturesPath, certOut string) (int, error) {
+	script := r.runnerScript()
+	if _, err := os.Stat(script); err != nil {
+		return 1, fmt.Errorf("KIT runner missing at %s (run make submodules)", script)
+	}
+	args := []string{script, "--trace", tracePath, "--fixtures", fixturesPath}
+	if certOut != "" {
+		args = append(args, "--cert-out", certOut)
+	}
+	cmd := exec.Command(r.python(), args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), nil
+		}
+		return 1, err
+	}
+	return 0, nil
+}
+
+func (r *defaultKITRunner) CompareLowView(outputFiles []string, minDeterminism float64) (int, error) {
+	oracle := r.lowViewOracle()
+	if _, err := os.Stat(oracle); err != nil {
+		return 1, fmt.Errorf("low-view oracle missing at %s", oracle)
+	}
+	if len(outputFiles) < 2 {
+		return 1, fmt.Errorf("low-view compare requires at least two output files")
+	}
+	args := append([]string{oracle, "--min-determinism", fmt.Sprintf("%.6f", minDeterminism)}, outputFiles...)
+	cmd := exec.Command(r.python(), args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), nil
+		}
+		return 1, err
+	}
+	return 0, nil
+}

--- a/core/evidence/replay.go
+++ b/core/evidence/replay.go
@@ -11,38 +11,53 @@ import (
 	"time"
 )
 
-// ReplayReport captures replay verification output for a v0.1 bundle.
+// ReplayReport captures replay verification output for a v0.1/v0.2 bundle.
 type ReplayReport struct {
-	ReportID    string   `json:"report_id"`
-	BundleRef   string   `json:"bundle_ref"`
-	Status      string   `json:"status"`
-	TraceFound  bool     `json:"trace_found"`
-	Errors      []string `json:"errors"`
-	Warnings    []string `json:"warnings"`
-	ReplayedAt  string   `json:"replayed_at"`
+	ReportID       string   `json:"report_id"`
+	BundleRef      string   `json:"bundle_ref"`
+	Status         string   `json:"status"`
+	StaticStatus   string   `json:"static_status,omitempty"`
+	ExecuteStatus  string   `json:"execute_status,omitempty"`
+	KitExitCode    *int     `json:"kit_exit_code,omitempty"`
+	LowViewResult  string   `json:"low_view_result,omitempty"`
+	TraceFound     bool     `json:"trace_found"`
+	Errors         []string `json:"errors"`
+	Warnings       []string `json:"warnings"`
+	ReplayedAt     string   `json:"replayed_at"`
 }
 
 // ReplayOptions configures replay verification.
 type ReplayOptions struct {
-	BundlePath string
-	OutPath    string
-	Strict     bool
-	RepoRoot   string
-	BaseDir    string
+	BundlePath     string
+	OutPath        string
+	Strict         bool
+	RepoRoot       string
+	BaseDir        string
+	Execute        bool
+	FixturesDir    string
+	OutDir         string
+	LowViewCompare bool
+	Runner         KITRunner
 }
 
-// ReplayBundle validates a bundle and verifies replay preconditions for execution traces.
+// ReplayBundle validates a bundle and optionally executes KIT replay.
 func ReplayBundle(opts ReplayOptions) (*ReplayReport, error) {
 	if opts.BaseDir == "" {
 		opts.BaseDir = filepath.Dir(opts.BundlePath)
 	}
+	if opts.RepoRoot == "" {
+		if root, err := FindRepoRoot(opts.BaseDir); err == nil {
+			opts.RepoRoot = root
+		}
+	}
 	report := &ReplayReport{
-		ReportID:   fmt.Sprintf("replay-%d", time.Now().UTC().UnixNano()),
-		BundleRef:  filepath.ToSlash(opts.BundlePath),
-		Status:     "pass",
-		Errors:     []string{},
-		Warnings:   []string{},
-		ReplayedAt: time.Now().UTC().Format(time.RFC3339),
+		ReportID:     fmt.Sprintf("replay-%d", time.Now().UTC().UnixNano()),
+		BundleRef:    filepath.ToSlash(opts.BundlePath),
+		Status:       "pass",
+		StaticStatus: "pass",
+		Errors:       []string{},
+		Warnings:     []string{},
+		ReplayedAt:   time.Now().UTC().Format(time.RFC3339),
 	}
 
 	valReport, err := ValidateBundle(ValidateOptions{
@@ -53,6 +68,7 @@ func ReplayBundle(opts ReplayOptions) (*ReplayReport, error) {
 	})
 	if err != nil {
 		report.Status = "fail"
+		report.StaticStatus = "fail"
 		report.Errors = append(report.Errors, valReport.Errors...)
 		if len(report.Errors) == 0 {
 			report.Errors = append(report.Errors, err.Error())
@@ -64,12 +80,14 @@ func ReplayBundle(opts ReplayOptions) (*ReplayReport, error) {
 	data, err := os.ReadFile(opts.BundlePath)
 	if err != nil {
 		report.Status = "fail"
+		report.StaticStatus = "fail"
 		report.Errors = append(report.Errors, err.Error())
 		return report, err
 	}
 	var bundle EvidenceBundle
 	if err := json.Unmarshal(data, &bundle); err != nil {
 		report.Status = "fail"
+		report.StaticStatus = "fail"
 		report.Errors = append(report.Errors, err.Error())
 		return report, err
 	}
@@ -84,18 +102,21 @@ func ReplayBundle(opts ReplayOptions) (*ReplayReport, error) {
 		traceData, readErr := os.ReadFile(tracePath)
 		if readErr != nil {
 			report.Status = "fail"
+			report.StaticStatus = "fail"
 			report.Errors = append(report.Errors, readErr.Error())
 			return report, readErr
 		}
 		var trace map[string]any
 		if err := json.Unmarshal(traceData, &trace); err != nil {
 			report.Status = "fail"
+			report.StaticStatus = "fail"
 			report.Errors = append(report.Errors, fmt.Sprintf("invalid execution trace JSON: %v", err))
 			return report, err
 		}
 		expected, err := CanonicalJSONDigest(trace, "trace_digest")
 		if err != nil {
 			report.Status = "fail"
+			report.StaticStatus = "fail"
 			report.Errors = append(report.Errors, err.Error())
 			return report, err
 		}
@@ -103,6 +124,7 @@ func ReplayBundle(opts ReplayOptions) (*ReplayReport, error) {
 		if actual != expected {
 			msg := fmt.Errorf("trace_digest mismatch: expected %s got %s", expected, actual)
 			report.Status = "fail"
+			report.StaticStatus = "fail"
 			report.Errors = append(report.Errors, msg.Error())
 			return report, msg
 		}
@@ -110,6 +132,17 @@ func ReplayBundle(opts ReplayOptions) (*ReplayReport, error) {
 	report.TraceFound = traceFound
 	if !traceFound {
 		report.Warnings = append(report.Warnings, "no execution-trace artifact; replay preconditions only partially satisfied")
+	}
+
+	if opts.Execute {
+		if err := runExecuteReplay(&opts, &bundle, report); err != nil {
+			report.Status = "fail"
+			report.Errors = append(report.Errors, err.Error())
+			if opts.OutPath != "" {
+				_ = WriteReplayReport(opts.OutPath, report)
+			}
+			return report, err
+		}
 	}
 
 	if opts.OutPath != "" {
@@ -121,6 +154,108 @@ func ReplayBundle(opts ReplayOptions) (*ReplayReport, error) {
 		return report, fmt.Errorf("replay verification failed")
 	}
 	return report, nil
+}
+
+func runExecuteReplay(opts *ReplayOptions, bundle *EvidenceBundle, report *ReplayReport) error {
+	tracePath, fixturesPath, err := resolveReplayPaths(opts, bundle)
+	if err != nil {
+		report.ExecuteStatus = "fail"
+		return err
+	}
+
+	runner := opts.Runner
+	if runner == nil {
+		runner, err = NewKITRunner(opts.RepoRoot)
+		if err != nil {
+			report.ExecuteStatus = "fail"
+			return err
+		}
+	}
+
+	outDir := opts.OutDir
+	if outDir == "" {
+		outDir = filepath.Join(opts.BaseDir, "replay-out")
+	}
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		report.ExecuteStatus = "fail"
+		return err
+	}
+
+	certOut := filepath.Join(outDir, "replay.cert.json")
+	code, err := runner.Run(tracePath, fixturesPath, certOut)
+	report.KitExitCode = &code
+	if err != nil {
+		report.ExecuteStatus = "fail"
+		return err
+	}
+	if code != 0 {
+		report.ExecuteStatus = "fail"
+		return fmt.Errorf("KIT runner exited with code %d", code)
+	}
+	report.ExecuteStatus = "pass"
+
+	lowView := opts.LowViewCompare
+	if bundle.ReplayContext != nil && bundle.ReplayContext.LowViewOracle {
+		lowView = true
+	}
+	if lowView {
+		certOut2 := filepath.Join(outDir, "replay2.cert.json")
+		code2, err2 := runner.Run(tracePath, fixturesPath, certOut2)
+		if err2 != nil {
+			report.LowViewResult = "fail"
+			return err2
+		}
+		if code2 != 0 {
+			report.LowViewResult = "fail"
+			return fmt.Errorf("KIT second run exited with code %d", code2)
+		}
+		lvCode, lvErr := runner.CompareLowView([]string{certOut, certOut2}, 99.9)
+		if lvErr != nil {
+			report.LowViewResult = "fail"
+			return lvErr
+		}
+		if lvCode != 0 {
+			report.LowViewResult = "fail"
+			return fmt.Errorf("low-view oracle exited with code %d", lvCode)
+		}
+		report.LowViewResult = "pass"
+	}
+	return nil
+}
+
+func resolveReplayPaths(opts *ReplayOptions, bundle *EvidenceBundle) (tracePath, fixturesPath string, err error) {
+	if bundle.ReplayContext != nil {
+		if bundle.ReplayContext.KitTracePath != "" {
+			tracePath = filepath.Join(opts.BaseDir, filepath.FromSlash(bundle.ReplayContext.KitTracePath))
+		}
+		if bundle.ReplayContext.FixturesPath != "" {
+			fixturesPath = filepath.Join(opts.BaseDir, filepath.FromSlash(bundle.ReplayContext.FixturesPath))
+		}
+	}
+	if opts.FixturesDir != "" {
+		fixturesPath = opts.FixturesDir
+	}
+	if tracePath == "" {
+		for _, ref := range bundle.Artifacts {
+			if ref.Role == "execution-trace" {
+				tracePath = filepath.Join(opts.BaseDir, filepath.FromSlash(ref.Path))
+				break
+			}
+		}
+	}
+	if fixturesPath == "" {
+		candidate := filepath.Join(opts.BaseDir, "fixtures")
+		if st, statErr := os.Stat(candidate); statErr == nil && st.IsDir() {
+			fixturesPath = candidate
+		}
+	}
+	if tracePath == "" {
+		return "", "", fmt.Errorf("no trace path resolved for execute replay")
+	}
+	if fixturesPath == "" {
+		return "", "", fmt.Errorf("no fixtures path resolved for execute replay")
+	}
+	return tracePath, fixturesPath, nil
 }
 
 // WriteReplayReport writes replay report JSON.

--- a/docs/guides/replay-guarantees.md
+++ b/docs/guides/replay-guarantees.md
@@ -2,85 +2,73 @@
 
 ## Replay model
 
-`pf evidence replay` consumes an Evidence v0.1 bundle, runs strict validation, and verifies execution-trace self-consistency. It is a **bundle-level audit step**, not a full TRACE-REPLAY-KIT or SWE-bench re-execution.
+`pf evidence replay` consumes an Evidence v0.1 or v0.2 bundle, runs strict validation, and verifies execution-trace self-consistency. With `--execute`, it also runs TRACE-REPLAY-KIT (`runner/replay_run.py`) using v0.2 `replay_context` or inferred fixture paths.
+
+## Modes
+
+| Mode | Flags | Guarantees |
+|------|-------|------------|
+| Static (default) | none | Schema, digests, `trace_digest`, optional `replay_context` path checks |
+| Execute | `--execute` | Static checks plus KIT run exit code |
+| Low-view | `--execute --low-view` | Two KIT runs + `oracles/lowview_equal.py` determinism check |
+
+v0.1 bundles without `replay_context` continue to work in static mode only.
 
 ## Replayable claims
 
 A bundle replay **may** establish:
 
-- Bundle manifest schema conformance
+- Bundle manifest schema conformance (v0.1 or v0.2)
 - Artifact presence and byte-level digests
 - `bundle_digest` integrity
 - `trace_digest` self-consistency when an `execution-trace` artifact is present
+- With `--execute`: KIT runner completed with exit code 0 for resolved trace/fixtures
+- With `--low-view`: low-view oracle pass between two KIT outputs
 
 ## Non-replayable claims
 
 Replay **does not** establish:
 
-- End-to-end system determinism
-- External API or model behavior reproducibility
-- CERT signature validity (use CERT tooling)
+- CERT DSSE signature validity (use CERT tooling)
 - PCS science-claim admission
 - Policy or proof correctness
+- Morph environment reproducibility
+- PCS or spec-tar lane compatibility
 
 ## Determinism assumptions
 
 - Canonical JSON digest rules in [`core/evidence/digest.go`](../../core/evidence/digest.go) are stable for a given input object
 - Trace files on disk are unchanged between pack and replay
+- KIT Python dependencies match `external/TRACE-REPLAY-KIT/runner/requirements.txt`
 - Clock fields in reports (`replayed_at`) are not used for pass/fail
 
 ## External dependency assumptions
 
-- `specs/evidence/v0.1/schemas/` present in the repository checkout
-- Artifact paths resolve relative to bundle base directory
-- TRACE-REPLAY-KIT is **not** invoked; traces are validated structurally only
+- `specs/evidence/v0.1/schemas/` (and v0.2 bundle schema when applicable) present in checkout
+- `make submodules` for `--execute` / `--low-view`
+- Artifact paths resolve relative to bundle base directory (`--base-dir`)
 
-## Input and fixture requirements
-
-- Valid v0.1 bundle JSON
-- For trace checks: one or more `execution-trace` role artifacts with valid `trace_digest`
-- Strict mode requires all referenced artifact files to exist
-
-## Report structure
-
-Replay emits JSON with:
+## Report structure (v0.2 fields)
 
 | Field | Meaning |
 |-------|---------|
-| `report_id` | Unique replay run identifier |
-| `bundle_ref` | Input bundle path |
-| `status` | `pass` or `fail` |
+| `status` | Overall `pass` or `fail` |
+| `static_status` | Static validation + trace digest phase |
+| `execute_status` | KIT run result when `--execute` |
+| `kit_exit_code` | Process exit code from KIT runner |
+| `low_view_result` | Low-view oracle result when requested |
 | `trace_found` | Whether an execution-trace artifact was present |
-| `errors` | Machine-readable failure reasons |
-| `warnings` | Non-fatal conditions (e.g. no trace artifact) |
-| `replayed_at` | RFC3339 timestamp |
+| `errors` / `warnings` | Machine-readable messages |
 
 ## Failure interpretation
 
 | Failure | Meaning |
 |---------|---------|
-| Validation errors | Bundle schema, digest, or missing artifact |
-| `trace_digest mismatch` | Trace JSON was tampered after digest computation |
-| `no execution-trace artifact` | Warning only; partial replay preconditions |
+| Static fail | Fix bundle, artifacts, or digests before execute |
+| Execute fail | KIT trace/fixtures mismatch or runner error |
+| Low-view fail | Non-deterministic outputs between two runs |
 
-A replay failure means **the bundle or trace failed v0.1 checks**, not necessarily that the original runtime execution was incorrect.
+## Related commands
 
-## Relation to runtime evidence
-
-Runtime `evidence_v01_binding` events link certs to optional bundle refs. Replay does not read binding JSONL directly; package binding outputs into bundles first.
-
-## Relation to Evidence v0.1 bundles
-
-Replay operates only on v0.1 bundle manifests. It does not consume PCS `EvidenceBundle.v0` or `so bundle pack` tar archives.
-
-## Known limitations
-
-- Does not call `so trace run`
-- Does not re-run SWE-bench instances
-- Warnings when no trace artifact is present still yield `pass` if validation succeeds
-
-## Related
-
-- [Forensic replay basic](forensic-replay-basic.md)
-- [Evidence replay tests](../../tests/evidence_replay/test_evidence_replay.py)
-- [Evidence model v0.1](../specs/evidence-model-v0.1.md)
+- `pf evidence trace import` — convert KIT trace JSON to v0.1 execution-trace artifact
+- `so trace run` — direct KIT invocation without Evidence bundle coupling

--- a/testbed/evidence-v0.2/run_deep_replay.sh
+++ b/testbed/evidence-v0.2/run_deep_replay.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Evidence v0.2 deep replay testbed (static + optional execute).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+PF="${PF:-./core/cli/pf/pf}"
+if [[ ! -x "$PF" && ! -f "$PF" && ! -x "./core/cli/pf/pf.exe" ]]; then
+  (cd core/cli/pf && go build -o pf .)
+  PF="./core/cli/pf/pf"
+fi
+if [[ -x "./core/cli/pf/pf.exe" ]]; then
+  PF="./core/cli/pf/pf.exe"
+fi
+
+EXAMPLE="specs/evidence/v0.2/examples/valid"
+BUNDLE="$EXAMPLE/deep-replay-bundle.json"
+
+echo "== Step 1: validate v0.2 bundle (strict) =="
+"$PF" evidence validate "$BUNDLE" --strict --base-dir "$EXAMPLE"
+
+echo "== Step 2: static replay =="
+"$PF" evidence replay --bundle "$BUNDLE" --base-dir "$EXAMPLE"
+
+if [[ "${1:-}" != "--execute" ]]; then
+  echo "Static deep replay complete (pass --execute for KIT run)."
+  exit 0
+fi
+
+if [[ ! -f external/TRACE-REPLAY-KIT/runner/replay_run.py ]]; then
+  echo "TRACE-REPLAY-KIT missing — run: make submodules" >&2
+  exit 1
+fi
+
+echo "== Step 3: execute + low-view =="
+OUT="$(mktemp -d)"
+"$PF" evidence replay --bundle "$BUNDLE" --base-dir "$EXAMPLE" --execute --low-view --out-dir "$OUT/replay"
+echo "Deep replay execute complete."

--- a/tests/evidence_replay/test_evidence_replay_execute.py
+++ b/tests/evidence_replay/test_evidence_replay_execute.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Deep replay execute tests (requires TRACE-REPLAY-KIT submodule)."""
+
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PF = REPO / "core" / "cli" / "pf" / "pf"
+BUNDLE = REPO / "specs" / "evidence" / "v0.2" / "examples" / "valid" / "deep-replay-bundle.json"
+KIT_RUNNER = REPO / "external" / "TRACE-REPLAY-KIT" / "runner" / "replay_run.py"
+
+
+def _pf_bin() -> Path:
+    for candidate in (PF, REPO / "core" / "cli" / "pf" / "pf.exe"):
+        if candidate.exists():
+            return candidate
+    subprocess.run(["go", "build", "-o", "pf", "."], cwd=REPO / "core" / "cli" / "pf", check=True)
+    return PF
+
+
+@pytest.fixture(scope="module")
+def pf_bin() -> Path:
+    return _pf_bin()
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="KIT execute replay runs on Linux CI")
+@pytest.mark.skipif(not KIT_RUNNER.is_file(), reason="TRACE-REPLAY-KIT missing (make submodules)")
+def test_evidence_replay_execute_low_view(pf_bin: Path, tmp_path: Path) -> None:
+    out = tmp_path / "replay-report.json"
+    proc = subprocess.run(
+        [
+            str(pf_bin),
+            "evidence",
+            "replay",
+            "--bundle",
+            str(BUNDLE),
+            "--base-dir",
+            str(BUNDLE.parent),
+            "--execute",
+            "--low-view",
+            "--out-dir",
+            str(tmp_path / "kit-out"),
+            "--out",
+            str(out),
+            "--json",
+        ],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["status"] == "pass"
+    assert report.get("execute_status") == "pass"
+    assert report.get("low_view_result") == "pass"


### PR DESCRIPTION
## Summary

- Add `kit_runner.go` and extend `replay.go` for `--execute` and `--low-view` replay
- Extend `pf evidence replay` with fixtures/out-dir flags and KIT runner integration
- Add `testbed/evidence-v0.2/run_deep_replay.sh` and pytest execute coverage
- Update replay guarantees guide for v0.2 deep replay boundaries

## Test plan

- [ ] `go test ./...` in `core/evidence`
- [ ] `pytest tests/evidence_replay -q`
- [ ] `bash testbed/evidence-v0.2/run_deep_replay.sh` (requires submodules)

Stack: PR 4/7 (base: `evidence-v02/schema-replay-context`)