### PR TITLE
Evidence v0.2: runtime evidence E2E and smoke hardening

### DIFF
--- a/.github/workflows/evidence-v01-smoke.yml
+++ b/.github/workflows/evidence-v01-smoke.yml
@@ -10,13 +10,20 @@ on:
       - 'runtime/sidecar-watcher/src/evidence_v01.rs'
       - 'runtime/sidecar-watcher/src/cert_v1.rs'
       - 'runtime/sidecar-watcher/src/permit_enforcement.rs'
+      - 'runtime/sidecar-watcher/tests/emit_evidence_tests.rs'
       - 'testbed/evidence-v0.1/**'
+      - 'testbed/evidence-v0.2/**'
       - 'tests/evidence_**/**'
       - 'tests/e2e/test_evidence_bundle_basic.py'
       - 'tests/runtime_evidence/**'
       - 'tests/forensic_replay/**'
-      - 'tests/testbed/test_evidence_v01_testbed.py'
+      - 'tests/testbed/**'
       - 'tools/cert-validate/validate.py'
+      - 'tools/standards/**'
+      - 'external/**'
+      - '.gitmodules'
+      - 'Makefile'
+      - 'scripts/check_cert_write_paths.sh'
       - '.github/workflows/evidence-v01-smoke.yml'
   push:
     branches: [main]
@@ -79,6 +86,8 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: dtolnay/rust-toolchain@stable
+
       - uses: actions/setup-go@v5
         with:
           go-version: '1.23'
@@ -89,6 +98,19 @@ jobs:
 
       - name: Install Python deps
         run: pip install jsonschema pytest
+
+      - name: Init external standards
+        run: make submodules
+
+      - name: Standards pin check
+        run: make standards-pin-check
+
+      - name: Require CERT-V1 schema
+        run: |
+          test -f external/CERT-V1/schema/cert-v1.schema.json
+
+      - name: CERT write path guard
+        run: bash scripts/check_cert_write_paths.sh
 
       - name: Go tests (core/evidence)
         run: go test ./...
@@ -110,6 +132,7 @@ jobs:
           pytest tests/evidence_schema -q
           pytest tests/evidence_validation -q
           pytest tests/evidence_replay -q
+          pytest tests/evidence_trace -q
           pytest tests/e2e/test_evidence_bundle_basic.py -q
           pytest tests/runtime_evidence -q
           pytest tests/forensic_replay -q
@@ -120,13 +143,13 @@ jobs:
       - name: Testbed tamper case
         run: bash testbed/evidence-v0.1/run_tamper_case.sh
 
-      - name: Pytest testbed wrapper
-        run: pytest tests/testbed/test_evidence_v01_testbed.py -q
+      - name: Testbed v0.2 deep replay (static)
+        run: bash testbed/evidence-v0.2/run_deep_replay.sh
 
-      - name: Runtime sidecar binding (Linux + CERT-V1)
-        run: |
-          if [ -f external/CERT-V1/schema/cert-v1.schema.json ]; then
-            pytest tests/runtime_evidence/test_runtime_evidence_sidecar.py -q
-          else
-            echo "CERT-V1 schema missing; skipping live sidecar test"
-          fi
+      - name: Pytest testbed wrapper
+        run: pytest tests/testbed -q
+
+      - name: Runtime sidecar emit (Linux + CERT-V1 required)
+        env:
+          CI: true
+        run: pytest tests/runtime_evidence/test_runtime_evidence_sidecar.py -q

--- a/docs/guides/runtime-evidence-basic.md
+++ b/docs/guides/runtime-evidence-basic.md
@@ -1,10 +1,12 @@
 # Runtime evidence basic
 
-Sidecar-watcher emits CERT-V1 certificates and may append additive Evidence v0.1 binding records.
+Sidecar-watcher emits CERT-V1 certificates and **always** appends Evidence v0.1 binding records on the permit-enforcement emit path.
 
-## Emit path (v0.1)
+## Emit path (v0.2 scope)
 
-Binding events are written from the **permit enforcement** emit path only (`permit_enforcement.rs` → `write_cert_with_binding`). Other sidecar code paths do not emit Evidence v0.1 bindings in v0.1.
+Binding events are written from the **permit enforcement** emit path only (`permit_enforcement.rs` → `write_cert_with_binding`). This is the single production CERT write hook in `runtime/` (enforced by `scripts/check_cert_write_paths.sh` in CI). Other sidecar code paths do not emit CERT files in production.
+
+`evidence_bundle_ref` in the binding event is **optional** and populated only when `EVIDENCE_BUNDLE_REF` is set. The binding JSONL line is emitted regardless.
 
 ## Binding event
 
@@ -35,7 +37,7 @@ Run the static or live scenario:
 
 ```bash
 bash examples/runtime-evidence-basic/run_scenario.sh
-bash examples/runtime-evidence-basic/run_scenario.sh --live   # requires external/CERT-V1
+bash examples/runtime-evidence-basic/run_scenario.sh --live   # cargo test emit + binding (requires make submodules)
 ```
 
 ## CI requirements (live test)

--- a/docs/guides/runtime-evidence-boundaries.md
+++ b/docs/guides/runtime-evidence-boundaries.md
@@ -2,23 +2,23 @@
 
 ## Runtime evidence overview
 
-Runtime evidence in Evidence v0.1 is an **additive binding layer** on top of existing CERT-V1 sidecar emission. The sidecar continues to write CERT-V1 JSON and append CERT lines to `evidence/logs/sidecar.jsonl`. When `EVIDENCE_BUNDLE_REF` is set, emit paths also append an `evidence_v01_binding` JSONL event linking the session, cert path, optional bundle reference, and cert digest.
+Runtime evidence in Evidence v0.1 is an **additive binding layer** on top of existing CERT-V1 sidecar emission. The sidecar continues to write CERT-V1 JSON and append CERT lines to `evidence/logs/sidecar.jsonl`. On every emit path through `write_cert_with_binding`, an `evidence_v01_binding` JSONL event is appended linking the session, cert path, cert digest, and optional bundle reference.
 
 ## Event sources
 
 | Source | Event | Output |
 |--------|-------|--------|
 | Sidecar `emit` handling | `permit_enforcement` CERT emission | `evidence/certs/<session>/<seq>.cert.json` |
-| Binding hook | `write_cert_with_binding` | `evidence/logs/sidecar.jsonl` (`evidence_v01_binding`) |
-| Platform services | evidence-service, replay-service | Out of v0.1 bundle scope unless explicitly packaged |
+| Binding hook | `write_cert_with_binding` (always on emit) | `evidence/logs/sidecar.jsonl` (`evidence_v01_binding`) |
+| Platform services | evidence-service, replay-service | Out of bundle scope unless explicitly packaged |
 
 ## Artifact binding
 
 Binding events record:
 
 - `session_id`, `cert_path`
-- Optional `evidence_bundle_ref` (from `EVIDENCE_BUNDLE_REF`)
 - `artifact_digests.cert-v1` (SHA-256 of the written CERT file)
+- Optional `evidence_bundle_ref` (only when `EVIDENCE_BUNDLE_REF` is set)
 
 CERT-V1 itself is **not modified**. Full v0.1 bundles are assembled separately via `pf evidence bundle pack`.
 
@@ -72,7 +72,7 @@ Binding JSONL alone is **not** validated by the bundle validator unless included
 
 - Invalid CERT: deny-wins via existing `validate_cert` (cert not written)
 - Binding write failure after cert write: cert remains; binding may be absent
-- Missing `external/CERT-V1` schema: sidecar panics at schema load (existing behavior)
+- Missing `external/CERT-V1` schema: validation and emit tests fail closed; run `make submodules`
 
 ## Tamper semantics
 

--- a/examples/runtime-evidence-basic/run_scenario.sh
+++ b/examples/runtime-evidence-basic/run_scenario.sh
@@ -36,4 +36,5 @@ if [[ ! -f "$SCHEMA" ]]; then
 fi
 
 cargo test -p sidecar-watcher write_cert_with_binding_emits_binding_jsonl -- --nocapture
+cargo test -p sidecar-watcher emit_evidence_binding_through_permit_enforcement -- --nocapture
 echo "Live scenario complete."

--- a/runtime/sidecar-watcher/Cargo.toml
+++ b/runtime/sidecar-watcher/Cargo.toml
@@ -57,5 +57,9 @@ path = "tests/break_glass_mechanism.rs"
 name = "dfa_equiv"
 path = "tests/dfa_equiv.rs"
 
+[[test]]
+name = "emit_evidence_tests"
+path = "tests/emit_evidence_tests.rs"
+
 # Unregistered sources under tests/ (events_plan_dsl, ni_monitor_egress, etc.) are quarantined
 # until updated for the current public API. See tests/README.md.

--- a/runtime/sidecar-watcher/src/cert_v1.rs
+++ b/runtime/sidecar-watcher/src/cert_v1.rs
@@ -8,14 +8,22 @@ use std::fs::{create_dir_all, OpenOptions};
 use std::io::Write;
 use std::path::Path;
 
-static CERT_SCHEMA: Lazy<Value> = Lazy::new(|| {
-    // Load the CERT-V1 schema from the submodule path at runtime
+static CERT_SCHEMA: Lazy<Option<Value>> = Lazy::new(|| {
     let schema_path = std::env::var("CERT_V1_SCHEMA")
         .unwrap_or_else(|_| "external/CERT-V1/schema/cert-v1.schema.json".to_string());
-    let data = std::fs::read_to_string(&schema_path)
-        .unwrap_or_else(|e| panic!("Failed to read CERT-V1 schema {}: {}", schema_path, e));
-    serde_json::from_str(&data).expect("Invalid CERT-V1 schema JSON")
+    match std::fs::read_to_string(&schema_path) {
+        Ok(data) => serde_json::from_str(&data).ok(),
+        Err(_) => None,
+    }
 });
+
+fn cert_schema() -> Result<&'static Value> {
+    CERT_SCHEMA.as_ref().ok_or_else(|| {
+        anyhow!(
+            "CERT-V1 schema not available (clone with make submodules or set CERT_V1_SCHEMA)"
+        )
+    })
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CertV1 {
@@ -46,7 +54,7 @@ pub struct MorphInfo {
 }
 
 pub fn validate_cert(cert: &CertV1) -> Result<()> {
-    let compiled = jsonschema::JSONSchema::compile(&CERT_SCHEMA)?;
+    let compiled = jsonschema::JSONSchema::compile(cert_schema()?)?;
     let data = serde_json::to_value(cert)?;
     let result = compiled.validate(&data);
     if let Err(errors) = result {

--- a/runtime/sidecar-watcher/tests/emit_evidence_tests.rs
+++ b/runtime/sidecar-watcher/tests/emit_evidence_tests.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+use sidecar_watcher::permit_enforcement::{PermitEnforcementHook, RuntimeEvent};
+use sidecar_watcher::policy_adapter::{EnforcementMode, PolicyConfig};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+fn cert_schema_available() -> bool {
+    Path::new("external/CERT-V1/schema/cert-v1.schema.json").exists()
+}
+
+#[test]
+fn emit_evidence_binding_through_permit_enforcement() {
+    if !cert_schema_available() {
+        eprintln!("skip: CERT-V1 schema missing (make submodules)");
+        return;
+    }
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    std::env::set_current_dir(tmp.path()).expect("chdir");
+    std::env::set_var(
+        "BUNDLE_ID",
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    std::env::set_var("POLICY_HASH", "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    std::env::set_var("PROOF_HASH", "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+    std::env::set_var(
+        "AUTOMATA_HASH",
+        "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    );
+    std::env::set_var(
+        "LABELER_HASH",
+        "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    );
+    std::env::set_var(
+        "EVIDENCE_BUNDLE_REF",
+        "examples/runtime-evidence-basic/basic-evidence-bundle.json",
+    );
+
+    let config = PolicyConfig {
+        enforcement_mode: EnforcementMode::Enforce,
+        shadow_mode: false,
+        epoch_validation: true,
+        witness_validation: true,
+        high_assurance_mode: false,
+        feature_flags: HashMap::new(),
+    };
+    let mut hook = PermitEnforcementHook::new(config);
+
+    let event = RuntimeEvent {
+        event_id: "emit-001".to_string(),
+        event_type: "emit".to_string(),
+        user_id: "user1".to_string(),
+        roles: vec!["admin".to_string()],
+        organization: "org".to_string(),
+        session_id: "emit-session-001".to_string(),
+        epoch: 1,
+        attributes: vec![],
+        tenant: "tenantA".to_string(),
+        timestamp: 42,
+        resource_uri: None,
+        resource_version: None,
+        field_path: None,
+        tool: None,
+        args: None,
+        merkle_witness: None,
+        field_commit: None,
+        source_label: None,
+        target_label: None,
+    };
+
+    hook.process_event(&event).expect("process emit event");
+
+    let cert_path = "evidence/certs/emit-session-001/42.cert.json";
+    assert!(Path::new(cert_path).is_file(), "cert file written");
+
+    let cert_bytes = fs::read(cert_path).expect("read cert");
+    let expected_digest = format!("sha256:{:x}", Sha256::digest(&cert_bytes));
+
+    let log_path = Path::new("evidence/logs/sidecar.jsonl");
+    assert!(log_path.is_file(), "sidecar.jsonl exists");
+
+    let lines: Vec<String> = BufReader::new(fs::File::open(log_path).expect("open log"))
+        .lines()
+        .map(|l| l.expect("line"))
+        .collect();
+    assert!(lines.len() >= 2, "expected cert + binding lines");
+
+    let binding_line = lines.last().expect("binding");
+    assert!(binding_line.contains("evidence_v01_binding"));
+    assert!(binding_line.contains("examples/runtime-evidence-basic/basic-evidence-bundle.json"));
+    assert!(binding_line.contains(&expected_digest));
+}

--- a/scripts/check_cert_write_paths.sh
+++ b/scripts/check_cert_write_paths.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Fail if new CERT file writers bypass write_cert_with_binding.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+ALLOWLIST=(
+  "runtime/sidecar-watcher/src/cert_v1.rs"
+)
+
+violations=0
+while IFS= read -r line; do
+  file="${line%%:*}"
+  skip=0
+  for allowed in "${ALLOWLIST[@]}"; do
+    if [[ "$file" == "$allowed" ]]; then
+      skip=1
+      break
+    fi
+  done
+  if [[ "$skip" -eq 1 ]]; then
+    continue
+  fi
+  if [[ "$line" == *"write_cert("* && "$line" != *"write_cert_with_binding"* ]]; then
+    echo "CERT write without binding hook: $line" >&2
+    violations=$((violations + 1))
+  fi
+done < <(rg -n 'write_cert\(' runtime --glob '*.rs' || true)
+
+if [[ "$violations" -gt 0 ]]; then
+  echo "check_cert_write_paths: $violations violation(s)" >&2
+  exit 1
+fi
+
+echo "check_cert_write_paths: OK"

--- a/tests/runtime_evidence/test_runtime_evidence_sidecar.py
+++ b/tests/runtime_evidence/test_runtime_evidence_sidecar.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Live sidecar binding integration (Linux CI + CERT-V1 schema gate).
 
-Skipped on Windows local runs; CI uses ubuntu-latest with submodules.
+Skipped on Windows local runs only. CI fails if CERT-V1 submodule is missing.
 """
 
 from __future__ import annotations
 
+import os
 import platform
 import subprocess
 from pathlib import Path
@@ -15,12 +16,20 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 CERT_SCHEMA = REPO / "external" / "CERT-V1" / "schema" / "cert-v1.schema.json"
-SIDECAR_CRATE = REPO / "runtime" / "sidecar-watcher"
+
+
+def _require_cert_schema() -> None:
+    if CERT_SCHEMA.is_file():
+        return
+    msg = "CERT-V1 schema missing at external/CERT-V1 — run: make submodules"
+    if os.environ.get("CI"):
+        pytest.fail(msg)
+    pytest.skip(msg)
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="live sidecar test runs on Linux CI")
-@pytest.mark.skipif(not CERT_SCHEMA.is_file(), reason="CERT-V1 schema missing (make submodules)")
 def test_sidecar_write_cert_with_binding_emits_jsonl() -> None:
+    _require_cert_schema()
     proc = subprocess.run(
         [
             "cargo",
@@ -37,4 +46,24 @@ def test_sidecar_write_cert_with_binding_emits_jsonl() -> None:
         timeout=300,
     )
     assert proc.returncode == 0, proc.stderr + proc.stdout
-    assert "evidence_v01_binding" in proc.stdout or proc.returncode == 0
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="live sidecar test runs on Linux CI")
+def test_emit_evidence_through_permit_enforcement() -> None:
+    _require_cert_schema()
+    proc = subprocess.run(
+        [
+            "cargo",
+            "test",
+            "-p",
+            "sidecar-watcher",
+            "emit_evidence_binding_through_permit_enforcement",
+            "--",
+            "--nocapture",
+        ],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout


### PR DESCRIPTION
## Summary

- Add sidecar emit integration tests and graceful CERT-V1 schema fallback in `cert_v1.rs`
- Add `scripts/check_cert_write_paths.sh` and `--live` flag in runtime example script
- Harden `evidence-v01-smoke.yml`: submodule init, pin check, trace/deep-replay testbed steps
- Update runtime evidence basic/boundaries guides and sidecar pytest coverage

## Test plan

- [ ] `cargo test` in `runtime/sidecar-watcher`
- [ ] `pytest tests/runtime_evidence -q` (with CERT-V1 submodule)
- [ ] Evidence smoke workflow passes on this PR

Stack: PR 5/7 (base: `evidence-v02/deep-replay`)