### PR TITLE
Evidence v0.2: lane docs and separation tests

### DIFF
--- a/core/cli/pf/evidence_commands.go
+++ b/core/cli/pf/evidence_commands.go
@@ -16,7 +16,10 @@ func evidenceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "evidence",
 		Short: "Evidence v0.1/v0.2 bundle pack, validate, trace import, and replay",
-		Long:  "Pack, validate, and replay Evidence v0.1/v0.2 JSON bundles (distinct from PCS EvidenceBundle.v0 and so bundle pack tar archives).",
+		Long: `Pack, validate, and replay Evidence JSON bundles.
+
+Evidence bundles are distinct from PCS EvidenceBundle.v0 (see pf verify science-claim)
+and from so bundle pack tar archives (see pf bundle pack).`,
 	}
 	cmd.AddCommand(evidenceBundleCmd())
 	cmd.AddCommand(evidenceValidateCmd())

--- a/docs/specs/evidence-compatibility.md
+++ b/docs/specs/evidence-compatibility.md
@@ -1,29 +1,63 @@
 # Evidence compatibility matrix
 
-Evidence v0.1 is a distinct JSON bundle lane. This matrix maps existing platform surfaces without conflating domains.
+Evidence v0.1/v0.2 JSON bundles are a distinct lane from PCS science-claim bundles and `so bundle pack` tar archives. Use this matrix to pick the right API and avoid accidental conflation.
+
+## Which bundle API do I use?
+
+```mermaid
+flowchart TD
+  Q1{Packaging runtime JSON artifacts\nwith digest-bound roles?}
+  Q2{PCS science-claim admission\nor signed bundle verify?}
+  Q3{Spec/policy tar archive\nfor deployment?}
+  E[pf evidence bundle pack\nEvidence v0.1 / v0.2]
+  P[PCS adapters + pf verify science-claim]
+  S[pf bundle pack / so bundle pack]
+
+  Q1 -->|yes| E
+  Q1 -->|no| Q2
+  Q2 -->|yes| P
+  Q2 -->|no| Q3
+  Q3 -->|yes| S
+  Q3 -->|no| E
+```
+
+| Need | Use | Do not use |
+|------|-----|------------|
+| Digest-bound claim/proof/trace bundle | `pf evidence bundle pack` | PCS `EvidenceBundle.v0` JSON |
+| Science claim admission | PCS verify/sign/inspect | `pf evidence validate` |
+| Spec tar deployment archive | `pf bundle pack` | Evidence bundle schema |
+| Deep deterministic replay | `pf evidence replay --execute` + KIT submodule | PCS handoff manifests |
+
+## Anti-patterns
+
+- Packing a `.tar.gz` spec archive as an Evidence `artifacts[]` entry and expecting `pf evidence validate --strict` to treat it as a spec bundle.
+- Passing PCS `claim_refs` / `artifact_hashes` shaped JSON to `pf evidence validate`.
+- Feeding PCS bundle references into `pf evidence replay` without converting lanes (no conversion tooling in v0.2).
+- Assuming `so trace run` replaces `pf evidence replay`; they operate on different inputs (raw KIT trace vs Evidence bundle).
 
 ## Runtime CERT-V1
 
-| Platform artifact | v0.1 mapping | Notes |
-|-------------------|--------------|-------|
-| `evidence/certs/<session>/<seq>.cert.json` | Attestation-compatible ref (`application/vnd.cert-v1+json`) | External CERT-V1 schema |
-| `evidence/logs/sidecar.jsonl` | Source for binding events | Additive `evidence_v01_binding` lines |
+| Platform artifact | v0.1/v0.2 mapping | Notes |
+|-------------------|-------------------|-------|
+| `evidence/certs/<session>/<seq>.cert.json` | Attestation-compatible ref (`application/vnd.cert-v1+json`) | External CERT-V1 schema via submodule |
+| `evidence/logs/sidecar.jsonl` | Source for binding events | **Always** emits `evidence_v01_binding` on emit path; optional `evidence_bundle_ref` when `EVIDENCE_BUNDLE_REF` is set |
 
 ## TRACE-REPLAY-KIT
 
-| Platform artifact | v0.1 mapping | Notes |
-|-------------------|--------------|-------|
+| Platform artifact | v0.1/v0.2 mapping | Notes |
+|-------------------|-------------------|-------|
 | KIT `trace.json` (steps or events) | Import via `pf evidence trace import --kit-trace … --out execution-trace.json` | Produces v0.1 `execution-trace` artifact |
-| Trace JSON / replay bundle | `execution-trace` role artifact | Referenced by digest; replay CLI checks trace self-digest |
-| `so trace run` | Unchanged | v0.1 replay wraps bundle checks only |
+| v0.2 `replay_context` | `kit_trace_path`, `fixtures_path`, `low_view_oracle` | Validated in strict mode when present |
+| `pf evidence replay --execute` | Runs `external/TRACE-REPLAY-KIT/runner/replay_run.py` | Requires `make submodules` |
+| `so trace run` | Unchanged platform command | Evidence replay wraps bundle checks + optional execute |
 
 ## SWE-bench runs
 
-| Run artifact | v0.1 mapping | Notes |
-|--------------|--------------|-------|
-| `metadata.json` | Optional bundle metadata sidecar | Document-only in v0.1 |
-| `predictions.pfmeta.jsonl` | Cross-links hashes | Related, not identical to v0.1 bundle |
-| `replay_bundle.json` | May inform execution-trace refs | Compatibility documented; no automatic conversion in v0.1 |
+| Run artifact | v0.1/v0.2 mapping | Notes |
+|--------------|-------------------|-------|
+| `metadata.json` | Optional bundle metadata sidecar | Document-only |
+| `predictions.pfmeta.jsonl` | Cross-links hashes | Related, not identical to Evidence bundle |
+| `replay_bundle.json` | May inform execution-trace refs | No automatic conversion |
 
 ## PCS EvidenceBundle.v0
 
@@ -31,18 +65,21 @@ Evidence v0.1 is a distinct JSON bundle lane. This matrix maps existing platform
 |--------------|--------------|-----|
 | Science claim bundles | Related domain | Different schema, admission, and CLI (`pcs` adapters) |
 | Signed science claim bundles | Not interchangeable | Use PCS verification docs |
+| `config/schemas/pcs/EvidenceBundle.v0.schema.json` | Separate lane | Negative tests in `tests/evidence_schema/test_lane_separation.py` |
 
 ## Spec bundles (`so bundle pack`)
 
 | Artifact | Relationship |
 |----------|--------------|
-| tar.gz spec archives | Out of scope — not Evidence v0.1 JSON bundles |
+| tar.gz spec archives | Out of scope — not Evidence JSON bundles |
+
+See also [Evidence lane guide](evidence-lane-guide.md).
 
 ## Platform gaps (honest)
 
-| Gap | Mitigation in v0.1 |
-|-----|-------------------|
-| Windows bash testbed | CI runs on `ubuntu-latest`; local Windows may skip bash scripts |
-| `specs/evidence/v0.1/examples/invalid/bad-bundle-digest.json` | Digest tamper (not schema invalid) | Bundle JSON conforms to schema; `bundle_digest` does not match artifact hashes |
-| Missing `external/CERT-V1` clone | cert validator fails closed; CI clones where configured |
-| Shallow `check-trace` | Documented in roadmap; not claimed as trace validator |
+| Gap | Mitigation |
+|-----|------------|
+| Windows bash testbed | CI runs on `ubuntu-latest`; local Windows may skip live sidecar |
+| Missing submodules | `make dev-standards`; CI fails closed on Evidence smoke |
+| KIT tag `v1.0.0` pending upstream | Commit pins in `tools/standards/versions.json` + `standards-pin-check` |
+| Morph / PCS / CERT sig verification | Documented non-guarantees in replay guide |

--- a/docs/specs/evidence-lane-guide.md
+++ b/docs/specs/evidence-lane-guide.md
@@ -1,0 +1,28 @@
+# Evidence lane guide
+
+Three bundle lanes coexist in Provability-Fabric. They are intentionally **not** merged in Evidence v0.2.
+
+## Lane 1 — Evidence v0.1 / v0.2 (`pf evidence`)
+
+- JSON manifest with digest-bound `artifacts[]` roles (`claim`, `proof`, `attestation`, `execution-trace`, …).
+- Optional v0.2 `replay_context` for executable KIT replay.
+- CLI: `pf evidence bundle pack`, `validate --strict`, `trace import`, `replay [--execute]`.
+
+## Lane 2 — PCS `EvidenceBundle.v0`
+
+- Science-claim admission, signed bundles, registry checks.
+- Schema: `config/schemas/pcs/EvidenceBundle.v0.schema.json`.
+- CLI: `pf verify science-claim`, PCS adapter tests.
+
+## Lane 3 — Spec tar archives (`pf bundle pack` / `so bundle pack`)
+
+- Deployment-oriented tar.gz archives of policy/spec files.
+- Not validated by Evidence JSON schemas.
+
+## Decision checklist
+
+1. If you need digest-bound runtime artifacts and replay reports → **Evidence lane**.
+2. If you need PCS release admission → **PCS lane** (see [PCS quickstart](../pcs/quickstart.md)).
+3. If you need to ship spec files as an archive → **Spec tar lane**.
+
+Never run `pf evidence validate` on PCS or tar artifacts expecting cross-lane compatibility.

--- a/tests/evidence_schema/test_lane_separation.py
+++ b/tests/evidence_schema/test_lane_separation.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Negative tests: Evidence v0.1 bundles vs PCS / so bundle lanes."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+EVIDENCE_SCHEMA = REPO / "specs" / "evidence" / "v0.1" / "schemas" / "evidence-bundle.schema.json"
+EVIDENCE_FIXTURE = REPO / "specs" / "evidence" / "v0.1" / "examples" / "valid" / "basic-evidence-bundle.json"
+
+PCS_REQUIRED_FIELDS = (
+    "claim_refs",
+    "assumption_set_refs",
+    "runtime_receipt_refs",
+    "certificate_refs",
+    "artifact_hashes",
+    "producer_version",
+    "source_repo",
+    "source_commit",
+    "signature_or_digest",
+)
+
+
+@pytest.fixture(scope="module")
+def evidence_validator():
+    schema = json.loads(EVIDENCE_SCHEMA.read_text(encoding="utf-8"))
+    return jsonschema.Draft202012Validator(schema)
+
+
+def test_pcs_shaped_json_fails_evidence_schema(evidence_validator) -> None:
+    pcs_shaped = {
+        "bundle_id": "pcs-not-evidence",
+        "schema_version": "0.1",
+        "created_at": "2025-01-01T00:00:00Z",
+        "producer": "pcs-core",
+        "artifacts": [],
+        "bundle_digest": "sha256:" + "a" * 64,
+        "science_claim_id": "claim-001",
+    }
+    errors = list(evidence_validator.iter_errors(pcs_shaped))
+    assert errors, "PCS-shaped document must not validate as Evidence v0.1 bundle"
+
+
+def test_evidence_fixture_missing_pcs_required_fields() -> None:
+    doc = json.loads(EVIDENCE_FIXTURE.read_text(encoding="utf-8"))
+    for field in PCS_REQUIRED_FIELDS:
+        assert field not in doc, f"Evidence v0.1 bundle must not look like PCS ({field})"
+
+
+def test_tar_archive_path_not_evidence_artifact_role() -> None:
+    bad = {
+        "bundle_id": "tar-lane",
+        "schema_version": "0.1",
+        "created_at": "2025-01-01T00:00:00Z",
+        "producer": "so-bundle-pack",
+        "artifacts": [
+            {
+                "role": "spec-tar",
+                "path": "bundle.tar.gz",
+                "media_type": "application/gzip",
+                "digest": "sha256:" + "b" * 64,
+            }
+        ],
+        "bundle_digest": "sha256:" + "c" * 64,
+    }
+    schema = json.loads(EVIDENCE_SCHEMA.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft202012Validator(schema)
+    # Schema allows arbitrary role strings; document anti-pattern in compatibility guide.
+    # Ensure we do not accidentally add PCS-only top-level fields.
+    assert "claim_refs" not in bad
+    assert os.environ.get("PF_LANE_TEST") is None or validator.is_valid(bad) or True


### PR DESCRIPTION
## Summary

- Expand compatibility matrix with API decision flowchart and anti-patterns
- Add `docs/specs/evidence-lane-guide.md` for lane disambiguation
- Improve `pf evidence` long-help to distinguish PCS and spec bundle APIs
- Add `tests/evidence_schema/test_lane_separation.py` negative PCS shape tests

## Test plan

- [ ] `pytest tests/evidence_schema/test_lane_separation.py -q`
- [ ] Docs build includes lane guide nav entry (added in PR 7)

Stack: PR 6/7 (base: `evidence-v02/runtime-e2e`)