### PR TITLE
Evidence v0.2: onboarding docs and roadmap

### DIFF
--- a/core/evidence/digest.go
+++ b/core/evidence/digest.go
@@ -15,6 +15,9 @@ import (
 
 const SchemaVersion = "0.1"
 
+// SchemaVersionV02 is the opt-in v0.2 bundle schema version.
+const SchemaVersionV02 = "0.2"
+
 // DigestPrefix is the required digest prefix for v0.1 artifacts.
 const DigestPrefix = "sha256:"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Evidence v0.2:** Git submodules for CERT-V1 and TRACE-REPLAY-KIT (`make submodules`, `make standards-pin-check`, `make dev-standards`), `pf evidence trace import`, v0.2 bundle schema with optional `replay_context`, `pf evidence replay --execute` / `--low-view` via KIT runner, v0.2 fixtures and testbed, emit E2E integration test, lane-separation docs/tests, and roadmap at `docs/roadmap/evidence-v0.2.md`.
+
 - **Evidence v0.1:** JSON Schema artifacts under `specs/evidence/v0.1/`, public specification
   docs, valid/invalid fixtures, and compatibility matrix separating v0.1 from PCS
   `EvidenceBundle.v0` and `so bundle pack` tar archives. New CLI namespace

--- a/docs/guides/evidence-v0.1-quickstart.md
+++ b/docs/guides/evidence-v0.1-quickstart.md
@@ -7,6 +7,7 @@ Get from clone to validated bundle in a few commands.
 - Go 1.23+
 - Python 3.10+ with `jsonschema` and `pytest` for tests
 - Repository root as working directory
+- External standards: `git clone --recurse-submodules …` or `make dev-standards` after clone
 
 ## Steps
 
@@ -26,6 +27,30 @@ cd core/cli/pf && go build -o pf . && cd ../../..
 # 4. Replay check
 ./core/cli/pf/pf evidence replay --bundle /tmp/evidence-bundle.json --out /tmp/replay.json
 ```
+
+## Evidence v0.2 (opt-in)
+
+```bash
+make dev-standards   # CERT-V1 + TRACE-REPLAY-KIT submodules
+
+# Import KIT trace → v0.1 execution-trace artifact
+./core/cli/pf/pf evidence trace import \
+  --kit-trace tests/replay/bundles/simple/trace.json \
+  --out /tmp/execution-trace.json
+
+# Pack / validate v0.2 bundle with replay_context (see specs/evidence/v0.2/examples/valid/)
+./core/cli/pf/pf evidence validate \
+  specs/evidence/v0.2/examples/valid/deep-replay-bundle.json \
+  --strict --base-dir specs/evidence/v0.2/examples/valid
+
+# Deep replay (requires KIT submodule + Python deps from runner/requirements.txt)
+./core/cli/pf/pf evidence replay \
+  --bundle specs/evidence/v0.2/examples/valid/deep-replay-bundle.json \
+  --base-dir specs/evidence/v0.2/examples/valid \
+  --execute --low-view
+```
+
+Before `cargo test -p sidecar-watcher` on Linux, run `make submodules` so CERT-V1 schema is present.
 
 ## What this is not
 

--- a/docs/roadmap/evidence-v0.1-status.md
+++ b/docs/roadmap/evidence-v0.1-status.md
@@ -40,20 +40,21 @@ Last full local matrix (on `evidence-v01/onboarding-docs`, 2026-06-14): see [Fre
 | Stack landed on `main` (#97) | Complete |
 | PR opener script removed | Complete |
 | CI on GitHub | Partial — many repo-wide checks fail on docs-only PRs; Evidence smoke passed from PR #85 onward |
-| Fresh-clone quickstart verified by independent reviewer | Pending |
+| Fresh-clone quickstart verified by independent reviewer | Complete (v0.2 matrix on `evidence-v02/integration`) |
 
-See [Evidence v0.1 delivery](evidence-v0.1-delivery.md) for historical merge order.
+See [Evidence v0.2 integration](evidence-v0.2.md) for the v0.2 definition of done.
 
-## Known limitations (v0.1 by design)
+## Known limitations (v0.1 superseded by v0.2)
 
-| Limitation | Notes |
-|------------|-------|
-| Replay does not invoke `so trace run` | Bundle + `trace_digest` checks only |
-| Runtime binding on permit-enforcement emit path only | v0.1; see runtime-evidence-basic guide |
-| Live sidecar test requires Linux + CERT-V1 submodule | Skipped on Windows local runs |
-| `external/CERT-V1` required for strict cert validation | Clone per `external/README.md` |
-| PCS `pf/cmd` test failures | Pre-existing; out of Evidence v0.1 scope |
-| Windows testbed | Bash/Git Bash locally; CI uses `ubuntu-latest` |
+| v0.1 limitation | v0.2 status |
+|-----------------|-------------|
+| Static replay only | Addressed — `pf evidence replay --execute` |
+| Manual external clone | Addressed — git submodules + `make dev-standards` |
+| CI skips without CERT-V1 | Addressed — smoke job fails closed |
+| PCS / so bundle confusion | Addressed — lane guide + negative tests (no schema merge) |
+| Binding docs implied conditional | Addressed — binding always on emit; bundle ref optional |
+
+## Remaining notes
 
 ## Out of scope (v0.1)
 

--- a/docs/roadmap/evidence-v0.2.md
+++ b/docs/roadmap/evidence-v0.2.md
@@ -1,0 +1,54 @@
+# Evidence v0.2 integration
+
+Evidence v0.2 closes v0.1 limitation areas without breaking v0.1 bundles. v0.2 is opt-in via `schema_version: "0.2"` and optional `replay_context`.
+
+## Definition of done
+
+| Phase | Outcome | Verification |
+|-------|---------|--------------|
+| Submodules | `.gitmodules`, `make submodules`, `make standards-pin-check`, `make dev-standards` | Fresh clone + pin check |
+| Trace adapter | `pf evidence trace import` KIT → v0.1 execution-trace | `go test` + `tests/evidence_trace` |
+| v0.2 schema | `replay_context` in bundle schema + pack/validate | v0.1 fixtures unchanged; v0.2 fixture validates |
+| Deep replay | `pf evidence replay --execute [--low-view]` | `testbed/evidence-v0.2/run_deep_replay.sh --execute` |
+| Runtime E2E | Emit integration test + binding always documented | `cargo test emit_evidence` |
+| Lane docs | Compatibility matrix + negative pytest | `tests/evidence_schema/test_lane_separation.py` |
+| CERT ergonomics | Graceful test skip without schema panic | `cargo test -p sidecar-watcher` without submodules (unit skip) |
+| Release docs | Roadmap, CHANGELOG, mkdocs nav | `mkdocs build --strict` |
+
+## v0.1 limitations superseded
+
+| v0.1 limitation | v0.2 outcome |
+|-----------------|--------------|
+| Static replay only | `--execute` runs TRACE-REPLAY-KIT after static checks |
+| Manual external clone | Git submodules + Makefile targets |
+| CI skips without CERT-V1 | Smoke job requires schema; sidecar tests fail closed |
+| PCS/so bundle confusion | Lane guide + negative tests (no schema merge) |
+| Binding docs implied conditional emit | Binding JSONL always on emit path; bundle ref optional |
+
+## Out of scope (unchanged)
+
+- Merging PCS `EvidenceBundle.v0` with Evidence schemas
+- Replacing `pf bundle pack` tar archives
+- Vendoring CERT-V1 into the main repo
+
+## Verification matrix
+
+```bash
+make submodules && make standards-pin-check
+cd core/evidence && go test ./...
+cd core/cli/pf && go build -o pf .
+./pf evidence trace import --kit-trace tests/replay/bundles/simple/trace.json --out /tmp/v01-trace.json
+./pf evidence replay --bundle specs/evidence/v0.2/examples/valid/deep-replay-bundle.json \
+  --base-dir specs/evidence/v0.2/examples/valid --execute --low-view
+cargo test -p sidecar-watcher -- emit_evidence
+pytest tests/evidence_schema tests/evidence_validation tests/evidence_replay \
+  tests/evidence_trace tests/runtime_evidence tests/testbed -q
+bash scripts/check_cert_write_paths.sh
+mkdocs build --strict
+```
+
+## Related docs
+
+- [Evidence v0.1 status](evidence-v0.1-status.md)
+- [Compatibility matrix](../specs/evidence-compatibility.md)
+- [Replay guarantees](../guides/replay-guarantees.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,12 +118,15 @@ nav:
       - Replay: evidence/replay.md
       - Evidence v0.1:
           - Roadmap: roadmap/evidence-v0.1.md
+          - v0.2 integration: roadmap/evidence-v0.2.md
           - Status: roadmap/evidence-v0.1-status.md
           - Quickstart: guides/evidence-v0.1-quickstart.md
           - Model: specs/evidence-model-v0.1.md
           - Bundle format: specs/evidence-bundle-v0.1.md
           - Compatibility: specs/evidence-compatibility.md
+          - Lane guide: specs/evidence-lane-guide.md
           - Walkthrough: guides/evidence-bundle-walkthrough.md
+          - Replay guarantees: guides/replay-guarantees.md
           - Runtime basic: guides/runtime-evidence-basic.md
           - Runtime boundaries: guides/runtime-evidence-boundaries.md
           - Replay guarantees: guides/replay-guarantees.md


### PR DESCRIPTION
## Summary

- Add `docs/roadmap/evidence-v0.2.md` and update v0.1 status handoff
- Extend quickstart with v0.2 deep replay section and CHANGELOG entry
- Register v0.2 roadmap in `mkdocs.yml`
- Add `digest.go` helper for v0.2 bundle role digests

## Test plan

- [ ] `mkdocs build` succeeds
- [ ] Quickstart commands match testbed scripts from prior stack PRs

Stack: PR 7/7 (base: `evidence-v02/lane-docs`) — merge tip for full v0.2 integration