### PR TITLE
Fix evidence smoke CI submodule checkout failure

### DIFF
--- a/.github/workflows/evidence-v01-smoke.yml
+++ b/.github/workflows/evidence-v01-smoke.yml
@@ -83,8 +83,6 @@ jobs:
     needs: evidence-validator
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
## Summary

- Remove `submodules: recursive` from the Evidence v0.1 smoke job checkout step.
- Checkout was failing with `fatal: No url found for submodule path vendor/mathlib` because `vendor/mathlib` is a stale gitlink in the index but has no entry in `.gitmodules`.
- The smoke job already runs `make submodules`, which explicitly inits only `external/CERT-V1` and `external/TRACE-REPLAY-KIT` (matches PR1 design).

## Test plan

- [x] Validated `.github/workflows/evidence-v01-smoke.yml` parses as valid YAML locally
- [ ] Merge and re-run **Evidence v0.1 smoke** workflow on main (or trigger via push to this PR path)
- [ ] Confirm smoke job reaches KIT deep replay and sidecar emit steps