### PR TITLE
fix: use bash for external standards init on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ help:
 # ---------- External standards submodules ----------
 submodules:
 	@$(ECHOOK) "Initializing external standards submodules..."
-	$(if $(filter Windows_NT,$(OS)),bash scripts/init_external_standards.sh,sh scripts/init_external_standards.sh)
+	bash scripts/init_external_standards.sh
 	@$(ECHOOK) "Submodules ready (run make standards-pin-check to verify tags)"
 
 standards-pin-check:


### PR DESCRIPTION
Dash sh on Ubuntu does not support pipefail; make submodules now invokes bash explicitly.