### PR TITLE
docs: Evidence v0.2 delivery sign-off (Phase 1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,19 @@ python tests/trust_fire_orchestrator.py
 
 Install Python dependencies as needed (e.g. `pip install -r tests/integration/requirements.txt`). Minimal install does not need Python tooling; for full dev run `pip install -r requirements-optional.txt` (see root `requirements-optional.txt`).
 
+### Evidence and CI
+
+Evidence changes should pass the [`evidence-v01-smoke.yml`](.github/workflows/evidence-v01-smoke.yml) workflow on Linux CI. Before opening a PR that touches `specs/evidence/**`, `core/evidence/**`, testbed scripts, or related tests:
+
+```bash
+make dev-standards   # CERT-V1 + TRACE-REPLAY-KIT submodules
+make evidence-verify # Go tests, pytest suites, v0.1 + v0.2 testbed scripts
+```
+
+`make evidence-verify` requires bash (Linux, WSL, or Git Bash on Windows). Clone external standards per [`external/README.md`](external/README.md). Fork maintainers and org workflows need repository secret **`STANDARDS_GITHUB_TOKEN`** for private `verifiable-ai-ci/*` repos.
+
+See [Evidence v0.2 delivery guide](docs/roadmap/evidence-v0.2-delivery.md) for the fresh-clone checklist and [Evidence v0.2 status](docs/roadmap/evidence-v0.2-status.md) for current delivery gates.
+
 ## Reuse and forking
 
 If you are forking the repo to build your own product or variant, see the [Reuse and extend](docs/guides/reuse-and-extend.md) guide. It covers:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ dev-up:
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2025 SentinelOps Platform Contributors
 
-.PHONY: help build test clean demo-up demo-down demo-setup install dev validate-certs lint bench security test-all helm-install helm-upgrade docs docs-serve quick-start logs rebuild lean-check-duplicates lean-forbid-shadowing vendor-mathlib no-runtime-placeholders submodules standards-pin-check dev-standards
+.PHONY: help build test clean demo-up demo-down demo-setup install dev validate-certs lint bench security test-all helm-install helm-upgrade docs docs-serve quick-start logs rebuild lean-check-duplicates lean-forbid-shadowing vendor-mathlib no-runtime-placeholders submodules standards-pin-check dev-standards evidence-verify
 
 # ---------- Cross-platform helpers ----------
 # Seconds to wait after starting containers (override with: make demo-up WAIT=10)
@@ -58,6 +58,7 @@ help:
 	@$(ECHOOK) "  make submodules      - Init/update external standards submodules"
 	@$(ECHOOK) "  make standards-pin-check - Verify submodule tags match versions.json"
 	@$(ECHOOK) "  make dev-standards   - submodules + standards-pin-check"
+	@$(ECHOOK) "  make evidence-verify - Evidence v0.1/v0.2 local gate (Linux/WSL/Git Bash)"
 	@$(ECHOOK) "  make lint            - Run linting on all code"
 	@$(ECHOOK) ""
 
@@ -73,6 +74,15 @@ standards-pin-check:
 
 dev-standards: submodules standards-pin-check
 	@$(ECHOOK) "External standards ready for local development"
+
+evidence-verify: dev-standards
+	@$(ECHOOK) "Running Evidence v0.1/v0.2 verification..."
+	cd core/evidence && go test ./...
+	pytest tests/evidence_schema tests/evidence_validation tests/evidence_replay \
+		tests/evidence_trace tests/runtime_evidence tests/testbed -q
+	bash testbed/evidence-v0.1/run_happy_path.sh
+	bash testbed/evidence-v0.2/run_deep_replay.sh
+	@$(ECHOOK) "Evidence verification passed"
 
 # ---------- Development ----------
 dev:

--- a/docs/roadmap/evidence-v0.1-status.md
+++ b/docs/roadmap/evidence-v0.1-status.md
@@ -39,7 +39,7 @@ Last full local matrix (on `evidence-v01/onboarding-docs`, 2026-06-14): see [Fre
 | 15 stacked PRs opened and merged (#82–#96) | Complete |
 | Stack landed on `main` (#97) | Complete |
 | PR opener script removed | Complete |
-| CI on GitHub | Evidence smoke green on Linux CI (PR #110, 2026-06-14); other repo-wide checks may still fail |
+| CI on GitHub | Evidence smoke green on Linux CI (PR #110 stack tip; PR #111 `main` workflow_dispatch run 27512113090, 2026-06-14); other repo-wide checks may still fail |
 | Fresh-clone quickstart verified by independent reviewer | Complete (v0.2 matrix on `evidence-v02/integration`) |
 
 See [Evidence v0.2 integration](evidence-v0.2.md) and [Evidence v0.2 status](evidence-v0.2-status.md).

--- a/docs/roadmap/evidence-v0.1.md
+++ b/docs/roadmap/evidence-v0.1.md
@@ -44,8 +44,13 @@ Evidence v0.1 delivers a minimal, reusable, validated path for packaging, valida
 
 - `pf check-trace` only verifies that `bundles/` exists; it is not a traceability validator.
 - `replayStatusCmdNew()` exists but is not registered; `replay status` uses the legacy handler.
-- `tools/cert-validate/validate.py` previously exited 0 when the external CERT-V1 schema was missing; strict mode now fails closed unless `--allow-missing-schema` is passed.
-- Windows: some replay integration tests may skip when bash or external clones are unavailable.
+
+### Historical limitations (resolved in v0.2)
+
+- ~~`tools/cert-validate/validate.py` exited 0 when the external CERT-V1 schema was missing~~ — strict mode now fails closed unless `--allow-missing-schema` is passed; CI smoke requires CERT-V1 via `make submodules`.
+- ~~Manual external clone for CERT-V1 / KIT~~ — git submodules + `make dev-standards` (see [Evidence v0.2 status](evidence-v0.2-status.md)).
+- ~~CI skipped evidence checks without CERT-V1~~ — smoke job fails closed when standards are unavailable.
+- ~~Windows: replay integration tests skipped without bash or external clones~~ — use WSL/Git Bash + `make dev-standards`; testbed scripts run under bash in CI.
 
 ## VERSION vs tags
 
@@ -70,4 +75,4 @@ Recorded on Windows checkout at `65bee159035e38e7a8f907ce2773226eca1ea4f3` (clea
 
 ## Status
 
-See [Evidence v0.1 status](evidence-v0.1-status.md) for the completion checklist.
+See [Evidence v0.1 status](evidence-v0.1-status.md) for the v0.1 completion checklist and [Evidence v0.2 status](evidence-v0.2-status.md) for current CI and delivery state.

--- a/docs/roadmap/evidence-v0.2-delivery.md
+++ b/docs/roadmap/evidence-v0.2-delivery.md
@@ -1,0 +1,105 @@
+# Evidence v0.2 delivery guide
+
+Historical guide for the eight stacked Evidence v0.2 pull requests plus CI hardening follow-ups. **Merged to `main` on 2026-06-14** (PRs #98–#104 into stacked bases; #105 landed `evidence-v02/onboarding` on `main`). CI hardening through #111.
+
+## Stack order
+
+Merge **in sequence**. Each PR targets the previous branch as base (except #105, which merges the stack tip onto `main`):
+
+| PR | Head branch | Base branch | Title |
+|----|-------------|-------------|-------|
+| 98 | `evidence-v02/submodules` | `main` | Evidence v0.2: external standards submodules and pin-check |
+| 99 | `evidence-v02/trace-adapter` | `evidence-v02/submodules` | Evidence v0.2: TRACE-REPLAY-KIT trace import adapter |
+| 100 | `evidence-v02/schema-replay-context` | `evidence-v02/trace-adapter` | Evidence v0.2: schema and replay_context validation |
+| 101 | `evidence-v02/deep-replay` | `evidence-v02/schema-replay-context` | Evidence v0.2: deep replay execution via KIT |
+| 102 | `evidence-v02/runtime-e2e` | `evidence-v02/deep-replay` | Evidence v0.2: runtime evidence E2E and smoke hardening |
+| 103 | `evidence-v02/lane-docs` | `evidence-v02/runtime-e2e` | Evidence v0.2: lane docs and separation tests |
+| 104 | `evidence-v02/onboarding` | `evidence-v02/lane-docs` | Evidence v0.2: onboarding docs and roadmap |
+| 105 | `evidence-v02/onboarding` | `main` | Evidence v0.2: land full stack on main |
+
+## Manual compare links (historical)
+
+If CLI auth is unavailable, open PRs via GitHub compare:
+
+- [PR98: main...submodules](https://github.com/SentinelOps-CI/provability-fabric/compare/main...evidence-v02/submodules)
+- [PR99: submodules...trace-adapter](https://github.com/SentinelOps-CI/provability-fabric/compare/evidence-v02/submodules...evidence-v02/trace-adapter)
+- [PR100: trace-adapter...schema-replay-context](https://github.com/SentinelOps-CI/provability-fabric/compare/evidence-v02/trace-adapter...evidence-v02/schema-replay-context)
+- [PR101: schema-replay-context...deep-replay](https://github.com/SentinelOps-CI/provability-fabric/compare/evidence-v02/schema-replay-context...evidence-v02/deep-replay)
+- [PR102: deep-replay...runtime-e2e](https://github.com/SentinelOps-CI/provability-fabric/compare/evidence-v02/deep-replay...evidence-v02/runtime-e2e)
+- [PR103: runtime-e2e...lane-docs](https://github.com/SentinelOps-CI/provability-fabric/compare/evidence-v02/runtime-e2e...evidence-v02/lane-docs)
+- [PR104: lane-docs...onboarding](https://github.com/SentinelOps-CI/provability-fabric/compare/evidence-v02/lane-docs...evidence-v02/onboarding)
+- [PR105: main...onboarding](https://github.com/SentinelOps-CI/provability-fabric/compare/main...evidence-v02/onboarding)
+
+Set the **base** branch to the left side of each compare (e.g. PR99 base = `evidence-v02/submodules`).
+
+## Review gates per PR
+
+Gates align with the [Evidence v0.2 definition of done](evidence-v0.2.md#definition-of-done):
+
+| PR | Topic | Minimum verification |
+|----|-------|---------------------|
+| 98 | Submodules | `make dev-standards`; `make standards-pin-check` |
+| 99 | Trace adapter | `go test ./...` in `core/evidence`; `pytest tests/evidence_trace -q` |
+| 100 | v0.2 schema | v0.1 fixtures unchanged; v0.2 fixture validates; `pytest tests/evidence_schema -q` |
+| 101 | Deep replay | `testbed/evidence-v0.2/run_deep_replay.sh --execute` |
+| 102 | Runtime E2E | `cargo test -p sidecar-watcher -- emit_evidence`; Linux sidecar pytest |
+| 103 | Lane docs | `pytest tests/evidence_schema/test_lane_separation.py -q` |
+| 104 | Release docs | `mkdocs build`; quickstart v0.2 section |
+| 105 | Land on main | Full Evidence smoke matrix green on Linux CI |
+
+### CI hardening (post-merge, #106–#111)
+
+| PR | Fix |
+|----|-----|
+| #106 | Remove broken `submodules: recursive` checkout |
+| #107 | `STANDARDS_GITHUB_TOKEN` + `scripts/init_external_standards.sh` |
+| #108 | Bash `pipefail` in init script |
+| #109 | KIT Python deps in smoke workflow |
+| #110 | Create testbed `out/` before replay report |
+| #111 | Migrate remaining workflows off `submodules: recursive`; `main` workflow_dispatch smoke green (run `27512113090`) |
+
+Green baselines: PR #110 (first full matrix after testbed fix) and PR #111 (`main` workflow_dispatch confirmation).
+
+## Fresh-clone verification checklist
+
+Run once on a clean machine before opening Evidence PRs (record result in [Evidence v0.2 status](evidence-v0.2-status.md)):
+
+```bash
+git clone https://github.com/SentinelOps-CI/provability-fabric.git
+cd provability-fabric
+git checkout main
+make dev-standards   # CERT-V1 + TRACE-REPLAY-KIT submodules (see external/README.md)
+make evidence-verify
+cd core/cli/pf && go build -o pf . && cd ../../..
+
+# v0.1 path
+./core/cli/pf/pf evidence validate \
+  specs/evidence/v0.1/examples/valid/basic-evidence-bundle.json --strict
+
+# v0.2 path
+./core/cli/pf/pf evidence trace import \
+  --kit-trace tests/replay/bundles/simple/trace.json \
+  --out /tmp/execution-trace.json
+./core/cli/pf/pf evidence validate \
+  specs/evidence/v0.2/examples/valid/deep-replay-bundle.json \
+  --strict --base-dir specs/evidence/v0.2/examples/valid
+./core/cli/pf/pf evidence replay \
+  --bundle specs/evidence/v0.2/examples/valid/deep-replay-bundle.json \
+  --base-dir specs/evidence/v0.2/examples/valid \
+  --execute --low-view
+
+# Runtime (Linux; requires make submodules for CERT-V1 schema)
+cargo test -p sidecar-watcher -- emit_evidence
+mkdocs build
+```
+
+For CI and private upstream repos, set repository secret **`STANDARDS_GITHUB_TOKEN`** (see [`external/README.md`](../../external/README.md)).
+
+**Local shortcut:** `make evidence-verify` runs standards init, Go/pytest suites, and both testbed scripts (Linux/WSL or Git Bash on Windows).
+
+## Post-merge hygiene
+
+1. Optional: delete remote branches `evidence-v02/*` (keep documented archives such as `refs/backup/pre-split-evidence-v02` if retained).
+2. Monitor [`evidence-v01-smoke.yml`](../../.github/workflows/evidence-v01-smoke.yml) on `main` for regressions; dispatch via Actions when validating delivery.
+3. Ensure org/repo secret **`STANDARDS_GITHUB_TOKEN`** is configured for fork PRs and workflows that call `make submodules`.
+4. Optional: delete remote `evidence-v01/*` branches after v0.1 archive policy is agreed (see [Evidence v0.1 delivery guide](evidence-v0.1-delivery.md#post-merge-hygiene)).

--- a/docs/roadmap/evidence-v0.2-status.md
+++ b/docs/roadmap/evidence-v0.2-status.md
@@ -14,7 +14,7 @@ Completion tracker for the Evidence v0.2 integration workstream. Implementation 
 | Lane docs | compatibility matrix, `test_lane_separation.py` | `pytest tests/evidence_schema/test_lane_separation.py -q` |
 | Release docs | `docs/roadmap/evidence-v0.2.md`, CHANGELOG, mkdocs | `mkdocs build` |
 
-Last full Evidence smoke matrix (PR #110, Linux CI, 2026-06-14): all three jobs green (`evidence-schema-only`, `evidence-validator`, `smoke`).
+Last full Evidence smoke matrix (Linux CI, 2026-06-14): all three jobs green (`evidence-schema-only`, `evidence-validator`, `smoke`). Green baselines: PR #110 (stack tip CI) and PR #111 (`main` workflow_dispatch run [27512113090](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27512113090)).
 
 ## CI hardening (post-merge)
 
@@ -25,6 +25,7 @@ Last full Evidence smoke matrix (PR #110, Linux CI, 2026-06-14): all three jobs 
 | Bash for `pipefail` in init script | #108 | `make submodules` works on Ubuntu default shell |
 | Install KIT Python deps in smoke | #109 | Deep replay `--execute` has `requests` et al. |
 | Create testbed `out/` before replay report | #110 | `run_happy_path.sh` passes end-to-end |
+| Migrate workflows off `submodules: recursive` | #111 | Plain checkout + `make submodules`; grep confirms zero `submodules:` usages |
 
 ## Delivery
 
@@ -33,10 +34,10 @@ Last full Evidence smoke matrix (PR #110, Linux CI, 2026-06-14): all three jobs 
 | 7 stacked PRs opened and merged (#98–#104) | Complete |
 | Stack landed on `main` (#105) | Complete |
 | Evidence smoke green on Linux CI (#110) | Complete |
-| `main` post-#110 workflow_dispatch confirmation | Pending (Actions queue) |
+| `main` workflow_dispatch confirmation (#111, run 27512113090) | Complete |
 | Remote branch cleanup (`evidence-v01/*`, `evidence-v02/*`) | Optional |
 
-See [Evidence v0.2 integration](evidence-v0.2.md) for definition of done and [Evidence v0.1 status](evidence-v0.1-status.md) for the v0.1 baseline.
+See [Evidence v0.2 integration](evidence-v0.2.md) for definition of done, [Evidence v0.2 delivery guide](evidence-v0.2-delivery.md) for stack and fresh-clone checklist, and [Evidence v0.1 status](evidence-v0.1-status.md) for the v0.1 baseline.
 
 ## Known limitations
 
@@ -44,7 +45,7 @@ See [Evidence v0.2 integration](evidence-v0.2.md) for definition of done and [Ev
 |------|--------|
 | Upstream tags `v1.0.0` not published | Pins use commit SHAs in `tools/standards/versions.json` |
 | Private `verifiable-ai-ci/*` repos | CI requires `STANDARDS_GITHUB_TOKEN` secret |
-| Other workflows using `submodules: recursive` | Being migrated to `make submodules` (no mathlib gitlink) |
+| Other workflows using `submodules: recursive` | Complete — removed in #111; use plain checkout + `make submodules` |
 | `mkdocs build --strict` | Pre-existing broken doc links (repo-wide, not Evidence-specific) |
 
 ## Out of scope (unchanged)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
           - v0.2 integration: roadmap/evidence-v0.2.md
           - Status: roadmap/evidence-v0.1-status.md
           - v0.2 status: roadmap/evidence-v0.2-status.md
+          - v0.2 delivery: roadmap/evidence-v0.2-delivery.md
           - Quickstart: guides/evidence-v0.1-quickstart.md
           - Model: specs/evidence-model-v0.1.md
           - Bundle format: specs/evidence-bundle-v0.1.md


### PR DESCRIPTION
## Summary

- Update Evidence v0.1/v0.2 status trackers: mark `main` workflow_dispatch (#111, run 27512113090) and submodules migration complete; note #110/#111 as green CI baselines
- Add `docs/roadmap/evidence-v0.2-delivery.md` (stack #98–#105, review gates, fresh-clone checklist, post-merge hygiene) and wire into mkdocs Evidence nav
- Move resolved v0.1 limitations to Historical limitations; point roadmap status to v0.2
- Add `make evidence-verify` target; document in delivery guide and CONTRIBUTING Evidence/CI section

## Test plan

- [ ] `mkdocs build` includes v0.2 delivery page
- [ ] `make evidence-verify` on Linux/WSL (optional; bash + submodules required)
- [ ] Docs-only PR; Evidence smoke unchanged
