### PR TITLE
ci: standards checkout parity (Phase 2)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -36,3 +36,26 @@ pr-comments.yml, cla-bot.yaml, bundle-check.yaml, dep-graph.yaml, verify-publish
 ## Maintenance
 
 When adding a workflow, add a one-line note in the appropriate section above so others can discover it without scanning the directory.
+
+## External standards checkout
+
+Workflows that validate CERT-V1, run TRACE-REPLAY-KIT replay, or link-check docs against
+`external/` paths must initialize standards explicitly:
+
+```yaml
+- uses: actions/checkout@v4
+- name: Init external standards
+  env:
+    STANDARDS_GITHUB_TOKEN: ${{ secrets.STANDARDS_GITHUB_TOKEN }}
+  run: make submodules
+```
+
+Do **not** use `actions/checkout` with `submodules: true` or `submodules: recursive` — the
+repo vendors Lean mathlib separately via `make vendor-mathlib`, and private upstream
+standards require `STANDARDS_GITHUB_TOKEN` (see [`tools/standards/README.md`](../tools/standards/README.md)).
+
+| Pattern | When |
+|---------|------|
+| Plain `actions/checkout@v4` | No CERT-V1/KIT dependency (demo-e2e, policy-build, most Rust/Go CI) |
+| Checkout + `make submodules` | cert-validate, replay, egress, platform-replay, platform-cert-validate, nightly-replay, evidence-v01-smoke, docs-build, standards-pin |
+| Checkout + `make vendor-mathlib` | Lean offline / reusable-ci-lean when `vendor/mathlib` is not cached |

--- a/.github/workflows/ci-nightly-pytest.yml
+++ b/.github/workflows/ci-nightly-pytest.yml
@@ -15,9 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
+      -         uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -22,8 +22,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
+
+      - name: Init external standards
+        env:
+          STANDARDS_GITHUB_TOKEN: ${{ secrets.STANDARDS_GITHUB_TOKEN }}
+        run: make submodules
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -44,8 +44,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/opa-test.yaml
+++ b/.github/workflows/opa-test.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Install conftest
         run: |

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/policy-gates.yaml
+++ b/.github/workflows/policy-gates.yaml
@@ -33,8 +33,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Set up Lean
         run: |
@@ -90,8 +88,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Download DFA artifacts
         uses: actions/download-artifact@v4
@@ -139,8 +135,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Download DFA artifacts
         uses: actions/download-artifact@v4
@@ -185,8 +179,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Download DFA artifacts
         uses: actions/download-artifact@v4
@@ -269,8 +261,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Download DFA artifacts
         uses: actions/download-artifact@v4
@@ -320,8 +310,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Download DFA artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/reusable-ci-lean.yml
+++ b/.github/workflows/reusable-ci-lean.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Set up Python (Lean gates)
         uses: actions/setup-python@v5

--- a/.github/workflows/reusable-ci-prepare.yml
+++ b/.github/workflows/reusable-ci-prepare.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/tools/standards/README.md
+++ b/tools/standards/README.md
@@ -1,0 +1,62 @@
+# External standards pinning
+
+Pinned copies of [CERT-V1](https://github.com/verifiable-ai-ci/CERT-V1) and
+[TRACE-REPLAY-KIT](https://github.com/verifiable-ai-ci/TRACE-REPLAY-KIT) live under
+`external/` as git submodules. This directory holds the **pin policy** and drift check.
+
+## versions.json
+
+| Field | Meaning |
+|-------|---------|
+| Top-level `"CERT-V1": "v1.0.0"` | **Intent** — the semver tag we expect upstream to publish |
+| Top-level `"TRACE-REPLAY-KIT": "v1.0.0"` | Same for the replay kit |
+| `pins.CERT-V1` | **Authoritative commit SHA** checked out until upstream tags exist |
+| `pins.TRACE-REPLAY-KIT` | Authoritative commit SHA for the kit |
+
+Upstream repos are private and may not have published `v1.0.0` tags yet. CI and local
+development use commit SHAs in `pins.*` as the source of truth.
+
+## check_pins.py
+
+[`check_pins.py`](check_pins.py) verifies each submodule:
+
+1. `remote.origin.url` matches the expected repository
+2. `HEAD` equals the SHA in `pins.*` (prefix match allowed)
+3. If an exact tag exists on `HEAD`, it must match the top-level semver intent
+
+When no tag exists on the pinned commit, the script accepts a commit-prefix match only.
+
+Run locally:
+
+```bash
+make submodules
+make standards-pin-check
+```
+
+Or together: `make dev-standards`.
+
+## Bumping pins
+
+1. Clone or update the upstream repo and identify the target commit (or tag when published).
+2. Test locally: `make dev-standards`, then Evidence/replay/cert workflows you touch.
+3. Update `pins.*` in [`versions.json`](versions.json). Update top-level semver keys if intent changes.
+4. Run `make standards-pin-check` and open a PR.
+5. Ensure CI has repository secret **`STANDARDS_GITHUB_TOKEN`** (see [`external/README.md`](../../external/README.md)).
+
+## CI checkout pattern
+
+Workflows that need CERT-V1 or TRACE-REPLAY-KIT must **not** use `actions/checkout` with
+`submodules: true` (stale gitlinks can fail). Use:
+
+```yaml
+- uses: actions/checkout@v4
+- name: Init external standards
+  env:
+    STANDARDS_GITHUB_TOKEN: ${{ secrets.STANDARDS_GITHUB_TOKEN }}
+  run: make submodules
+```
+
+Lean builds use `make vendor-mathlib` instead (see [`lean-offline.yaml`](../../.github/workflows/lean-offline.yaml)).
+Workflows with no external dependency use plain checkout only.
+
+See [`.github/WORKFLOWS.md`](../../.github/WORKFLOWS.md) for the workflow map.


### PR DESCRIPTION
## Summary
- Replace `actions/checkout` `submodules: true` with plain checkout across CI workflows
- Initialize CERT-V1/KIT in docs-build via `make submodules` + `STANDARDS_GITHUB_TOKEN`
- Add `tools/standards/README.md` pinning policy and document checkout patterns in `.github/WORKFLOWS.md`

## Test plan
- [ ] standards-pin.yml green on this PR
- [ ] docs-build initializes submodules when triggered
- [ ] cert-validate / replay workflows unchanged (already use make submodules)