### PR TITLE
ci: standards parity — artifact v4 and token docs

### DIFF
--- a/.github/workflows/allowlist-sync.yaml
+++ b/.github/workflows/allowlist-sync.yaml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload drift report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: allowlist-drift-report
           path: /tmp/drift_report.json

--- a/.github/workflows/chaos-nightly.yaml
+++ b/.github/workflows/chaos-nightly.yaml
@@ -311,7 +311,7 @@ jobs:
           EOF
 
       - name: Upload chaos report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: chaos-report-${{ github.run_number }}
           path: chaos-report.md

--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -119,7 +119,7 @@ jobs:
         fi
     
     - name: Store demo artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: demo-e2e-artifacts

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -37,7 +37,7 @@ jobs:
           cargo fuzz run json_actions -- -runs=1000 -max_total_time=120
 
       - name: Upload fuzz artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: fuzz-artifacts

--- a/.github/workflows/incident-e2e.yaml
+++ b/.github/workflows/incident-e2e.yaml
@@ -370,7 +370,7 @@ jobs:
             "$SLACK_WEBHOOK_URL"
 
       - name: Upload summary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-summary
           path: e2e-summary.md

--- a/.github/workflows/paper-conformance.yaml
+++ b/.github/workflows/paper-conformance.yaml
@@ -346,7 +346,7 @@ jobs:
           cargo bench --all -- --output-format=json > performance_report.json
 
       - name: Upload Performance Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: performance-report
           path: runtime/sidecar-watcher/performance_report.json
@@ -376,7 +376,7 @@ jobs:
           cargo geiger --output-format json > security_report.json
 
       - name: Upload Security Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: security-report
           path: runtime/sidecar-watcher/security_report.json
@@ -401,7 +401,7 @@ jobs:
           cargo test --doc --all-features
 
       - name: Upload Documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: runtime/sidecar-watcher/target/doc

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -43,7 +43,7 @@ jobs:
           python scripts/bench.py --count 100000 --output perf-results.json
 
       - name: Upload performance results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: perf-results-${{ github.run_number }}
           path: perf-results.json

--- a/.github/workflows/performance-gate.yaml
+++ b/.github/workflows/performance-gate.yaml
@@ -213,7 +213,7 @@ jobs:
             });
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-results-${{ matrix.rust-version }}
           path: |

--- a/.github/workflows/platform-cert-validate.yml
+++ b/.github/workflows/platform-cert-validate.yml
@@ -47,7 +47,7 @@ jobs:
         python tools/compliance/check_compliance.py --threshold 0.999
     
     - name: Upload validation report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: cert-validation-report

--- a/.github/workflows/platform-perf-smoke.yml
+++ b/.github/workflows/platform-perf-smoke.yml
@@ -60,7 +60,7 @@ jobs:
         python tools/perf/generate_report.py k6-results.json
     
     - name: Upload performance results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: performance-results

--- a/.github/workflows/platform-replay.yml
+++ b/.github/workflows/platform-replay.yml
@@ -57,7 +57,7 @@ jobs:
         python tools/replay/generate_report.py replay_artifacts/
     
     - name: Upload replay artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: replay-artifacts

--- a/.github/workflows/policy-build.yml
+++ b/.github/workflows/policy-build.yml
@@ -99,7 +99,7 @@ jobs:
         echo "$COMMENT" > pr-comment.md
     
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: policy-build-artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,19 @@ make evidence-verify # Go tests, pytest suites, v0.1 + v0.2 testbed scripts
 make docs-strict     # mkdocs build --strict (docs-only PRs)
 ```
 
-`make evidence-verify` requires bash (Linux, WSL, or Git Bash on Windows). Clone external standards per [`external/README.md`](external/README.md). Fork maintainers and org workflows need repository secret **`STANDARDS_GITHUB_TOKEN`** for private `verifiable-ai-ci/*` repos.
+`make evidence-verify` requires bash (Linux, WSL, or Git Bash on Windows). Clone external standards per [`external/README.md`](external/README.md).
+
+#### `STANDARDS_GITHUB_TOKEN` (org admin)
+
+CI workflows that call `make submodules` need a repository secret so GitHub Actions can clone private standards repos (`verifiable-ai-ci/CERT-V1`, `verifiable-ai-ci/TRACE-REPLAY-KIT`). **Org admin** must add the secret; contributors cannot self-serve it on the upstream org repo.
+
+1. Create a fine-grained PAT (or classic PAT) owned by a bot/service account with **read** access to `verifiable-ai-ci/CERT-V1` and `verifiable-ai-ci/TRACE-REPLAY-KIT`.
+2. In GitHub: **Settings → Secrets and variables → Actions → New repository secret**.
+3. Name: `STANDARDS_GITHUB_TOKEN`, value: the PAT.
+4. Verify locally (with the same token exported): `STANDARDS_GITHUB_TOKEN=<pat> make dev-standards`.
+5. Verify in CI: re-run **Standards Pin Drift Check** or **Evidence v0.1 smoke** via `workflow_dispatch`; the `make submodules` step should succeed in the log.
+
+Workflows using this secret are listed in [CI health matrix — Required secrets](docs/internal/ci-health-matrix.md#required-secrets-org-prerequisites). Forks without the secret can still run most gates; standards/replay jobs fail until the secret is configured or submodules are vendored locally.
 
 See [Evidence v0.2 delivery guide](docs/roadmap/evidence-v0.2-delivery.md) for the fresh-clone checklist and [Evidence v0.2 status](docs/roadmap/evidence-v0.2-status.md) for current delivery gates.
 
@@ -112,7 +124,13 @@ See [Evidence v0.2 delivery guide](docs/roadmap/evidence-v0.2-delivery.md) for t
 | Docs only | `make docs-strict` | `docs-build.yaml`, `docs-deploy.yaml` |
 | Code (general) | `go test`, `cargo test`, targeted pytest | `ci.yml` reusable jobs |
 
-Repo-wide triage and known failures: [CI health matrix](docs/internal/ci-health-matrix.md). Fork and org workflows need **`STANDARDS_GITHUB_TOKEN`** for private `verifiable-ai-ci/*` repos.
+Repo-wide triage and known failures: [CI health matrix](docs/internal/ci-health-matrix.md). Do not admin-merge while required checks are red (see **CI policy** below).
+
+### CI policy
+
+- **No admin merge on red:** merge only when all required status checks for the PR scope are green. Document any exception in the PR body and update the health matrix.
+- **Local gates before CI PRs:** `make dev-standards`, `make evidence-verify` (evidence paths), `make docs-strict` (docs), `make proto-lint proto-validate` (protobuf).
+- **Inventory:** run `scripts/ci_workflow_inventory.sh` on `main` after large workflow changes; see [CI health matrix](docs/internal/ci-health-matrix.md).
 
 ## Reuse and forking
 

--- a/docs/internal/ci-health-matrix.md
+++ b/docs/internal/ci-health-matrix.md
@@ -12,11 +12,22 @@ Triage snapshot for `main` as of 2026-06-15 after CI hardening PR #118.
 
 ## Standards / token parity
 
-| Workflow | Known failure | Fix | Status |
-|----------|---------------|-----|--------|
-| docs-build | Private submodule checkout | Plain checkout + `make submodules` (#113/#114) | Fixed |
-| cert-validate, replay, egress, platform-* | Same | Already on `make submodules` pattern | OK |
-| nightly-replay | Invalid YAML (triplicate workflow definitions) | Deduplicated workflow (#115) | Fixed |
+Verified on `main` (post-#118): each workflow below runs `make submodules` with `STANDARDS_GITHUB_TOKEN` in the job env.
+
+| Workflow | `make submodules` + token | Notes |
+|----------|---------------------------|-------|
+| `docs-build.yaml` | Yes | Plain checkout + submodules (#113/#114) |
+| `cert-validate.yml` | Yes | |
+| `replay.yml` | Yes | Docker replay runner |
+| `egress.yml` | Yes | |
+| `standards-pin.yml` | Yes | Pin drift gate |
+| `evidence-v01-smoke.yml` | Yes | Evidence gate |
+| `platform-cert-validate.yml` | Yes | |
+| `platform-replay.yml` | Yes | |
+| `nightly-replay.yml` | Yes | Scheduled replay |
+| `morph-replay.yml` | N/A | Uses in-repo `tests/replay/bundles` only |
+
+`actions/upload-artifact@v3` → `@v4` bump tracked in standards-parity PR (#119+).
 
 ## Main CI (`ci.yml` reusable jobs)
 
@@ -92,16 +103,28 @@ Triage snapshot for `main` as of 2026-06-15 after CI hardening PR #118.
 
 ## Required secrets (org prerequisites)
 
+### `STANDARDS_GITHUB_TOKEN` setup (org admin)
+
+| Step | Action |
+|------|--------|
+| 1 | Create PAT (fine-grained or classic) with **read** on `verifiable-ai-ci/CERT-V1` and `verifiable-ai-ci/TRACE-REPLAY-KIT` |
+| 2 | Repo **Settings → Secrets and variables → Actions → New repository secret** |
+| 3 | Name `STANDARDS_GITHUB_TOKEN`, paste PAT |
+| 4 | Local check: `STANDARDS_GITHUB_TOKEN=<pat> make dev-standards` |
+| 5 | CI check: `workflow_dispatch` **Evidence v0.1 smoke** or **Standards Pin Drift Check** — `make submodules` must pass |
+
+Contributor-facing steps: [CONTRIBUTING.md — STANDARDS_GITHUB_TOKEN](../../CONTRIBUTING.md).
+
 | Secret / service | Workflows blocked | Action |
 |------------------|-------------------|--------|
-| `STANDARDS_GITHUB_TOKEN` | `platform-cert-validate.yml`, `cert-validate.yml`, `replay.yml`, `evidence-v01-smoke.yml`, `standards-pin.yml`, `docs-build.yaml`, `egress.yml`, `morph-replay.yml`, `nightly-replay.yml`, `platform-replay.yml` | Org admin: PAT with read access to `verifiable-ai-ci/CERT-V1` and `verifiable-ai-ci/TRACE-REPLAY-KIT`; verify with `make dev-standards` in CI log |
+| `STANDARDS_GITHUB_TOKEN` | `platform-cert-validate.yml`, `cert-validate.yml`, `replay.yml`, `evidence-v01-smoke.yml`, `standards-pin.yml`, `docs-build.yaml`, `egress.yml`, `nightly-replay.yml`, `platform-replay.yml` | Org admin steps above; each workflow runs `make submodules` with `STANDARDS_GITHUB_TOKEN` env |
 | CLA hosted service | `cla-bot.yaml` (PR only after #118) | **Option B applied:** no `push: main`; skip when `/health` fails. Option A: restore hosted API at URL in `cla/cla.json` |
 | `CI_PAT` (optional) | `release.yaml` cross-repo dispatch | Only if release workflows must pass in closure sweep |
 | `AWS_*` (optional) | `dr-cross.yaml`, `evidence.yaml` | Only if DR/evidence collection scheduled jobs are in scope |
 
 | Secret | Workflows | Action if missing |
 |--------|-----------|-------------------|
-| `STANDARDS_GITHUB_TOKEN` | Evidence smoke, cert/replay/docs build, standards-pin | Add PAT with read access to `verifiable-ai-ci/*` |
+| `STANDARDS_GITHUB_TOKEN` | Evidence smoke, cert/replay/docs build, standards-pin, platform-cert/replay, egress, nightly-replay | Org admin: see setup table above |
 | `GITHUB_TOKEN` | Default | Auto-provided |
 | `CI_PAT` | release.yaml pf-testbed dispatch | Optional; release tags only |
 | `AWS_*` | dr-cross, evidence collection | Optional; scheduled/AWS workflows only |


### PR DESCRIPTION
## Summary
- Bump remaining `actions/upload-artifact@v3` to `@v4` across platform, bench, perf, and policy workflows.
- Document `STANDARDS_GITHUB_TOKEN` org-admin setup in CONTRIBUTING and ci-health-matrix.
- Verify standards workflows use `make submodules` + token env.

## Test plan
- [ ] actionlint on workflow diff
- [ ] Platform CERT / Replay no longer fail at deprecated artifact setup