### PR TITLE
docs: record PR #128 merge and post-closure ceremony

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Evidence program closure:** [evidence-program-closure.md](roadmap/evidence-program-closure.md) — v0.1+v0.2 vision complete, full-green CI criterion, org prerequisites, Phase 6 ceremony. CI hardening **#118** merged (`3f150b15`); post-merge smoke [27596580912](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596580912). Closure stack PRs **#121–#127** (`ci/standards-parity` through `docs/evidence-program-closure`). Phase 6 dispatches: smoke [27597765777](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27597765777), CI [27597765883](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27597765883). Branch protection applied on `main`. Inventory script: `scripts/ci_workflow_inventory.sh` (exit 1 post-stack — see closure doc).
+- **Evidence program closure:** [evidence-program-closure.md](roadmap/evidence-program-closure.md) — v0.1+v0.2 vision complete, full-green CI criterion, org prerequisites, Phase 6 ceremony. CI hardening **#118** merged (`3f150b15`); closure stack **#121–#128** landed on `main` (`de104223` tip). Post-#128 ceremony: smoke [27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269), CI [27616317486](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616317486). Branch protection on `main`. Inventory: `scripts/ci_workflow_inventory.sh` (8/67 gated green post-#128 — exit 1; see closure doc).
 
 ## [Unreleased] - Bench / eval pipeline hardening
 

--- a/docs/roadmap/evidence-program-closure.md
+++ b/docs/roadmap/evidence-program-closure.md
@@ -33,7 +33,7 @@ Reusable-only workflows (`workflow_call`) are tracked but not gating until invok
 | #126 | `ci/lean-research` | lean-offline, lean-morph, morph-replay, paper-conformance |
 | #125 | `ci/nightly-batch` | nightly-replay, ci-nightly-pytest, redteam, chaos smoke |
 | #127 | `docs/evidence-program-closure` | Closure sign-off page, CHANGELOG entry |
-| #128 | `ci/post-closure-hotfixes` | actionlint/docs-build/cert-validate hotfixes (**open** — needs approving review) |
+| #128 | `ci/post-closure-hotfixes` | actionlint/docs-build/cert-validate hotfixes — **merged** `de104223` (2026-06-16) |
 
 ## Org prerequisites (remaining blockers)
 
@@ -57,7 +57,12 @@ Setup steps: [CONTRIBUTING.md](https://github.com/SentinelOps-CI/provability-fab
 
 ### Inventory run (2026-06-16)
 
-`scripts/ci_workflow_inventory.sh` on `main` post-closure stack (#121–#127): **exit 1** — 67 gated (push/schedule) workflows, 6 green, 56 red, 23 unknown/no-run (summary from full inventory pass). Evidence smoke and standards-pin green; remaining red lanes are path-filtered push failures, optional AWS/Morph secrets, and infra-heavy Kind/Litmus jobs. Re-run after post-#127 hotfixes land on `main`.
+| Pass | Gated | Green | Red | Unknown |
+|------|------:|------:|----:|--------:|
+| Post-#127 | 67 | 6 | 56 | 21 |
+| Post-#128 (`de104223`) | 67 | 8 | 56 | 21 |
+
+`scripts/ci_workflow_inventory.sh` on `main` after **#128** merge: **exit 1** (full-green criterion not met). Gains include `proto-compat.yaml` success; remaining red lanes are path-filtered push failures, optional AWS/Morph secrets, and infra-heavy Kind/Litmus jobs. Post-#128 ceremony dispatches: Evidence smoke [27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269), CI [27616317486](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616317486).
 
 Use Git Bash on Windows (`export PATH="/c/Program Files/GitHub CLI:$PATH"`) — WSL `bash` may not see `gh`.
 

--- a/docs/roadmap/evidence-v0.2-status.md
+++ b/docs/roadmap/evidence-v0.2-status.md
@@ -8,8 +8,9 @@ Completion tracker for the Evidence v0.2 integration workstream. Implementation 
 |------|--------|
 | Merge commit | `3f150b1569b8dd50061d57ed99f34aa4b8dfffe6` |
 | Post-merge smoke | [workflow_dispatch 27596580912](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596580912) |
-| Closure stack | #121–#126 (`ci/standards-parity` … `ci/nightly-batch`) |
-| Sign-off page | [evidence-program-closure.md](evidence-program-closure.md) (#127) |
+| Closure stack | #121–#128 (`ci/standards-parity` … `ci/post-closure-hotfixes`) |
+| Sign-off page | [evidence-program-closure.md](evidence-program-closure.md) (#127); hotfixes **#128** merged `de104223` |
+| Post-#128 ceremony | Smoke [27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269), CI [27616317486](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616317486) |
 | Phase 6 ceremony | Smoke [27597765777](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27597765777), CI [27597765883](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27597765883) |
 
 ## Implementation (branch stack)


### PR DESCRIPTION
## Summary
- Update evidence-program-closure, evidence v0.2 status, and CHANGELOG to reflect PR #128 merged on main.
- Record the post-#128 ceremony dispatch run IDs and latest inventory counts.

## Test plan
- [ ] Open docs pages in mkdocs and verify links resolve.
- [ ] Confirm referenced GitHub Actions run IDs exist and are public.
