### PR TITLE
docs: Evidence acceptance gap analysis closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,6 @@ workspaces_verify_preflight_smoke/
 
 core/cli/pf/pf
 
+# Private MoU evidence packets (local only; never commit)
+private/
+

--- a/docs/guides/runtime-evidence-boundaries.md
+++ b/docs/guides/runtime-evidence-boundaries.md
@@ -49,7 +49,7 @@ Runtime binding records **what the sidecar emitted** and **optional cross-links*
 - Full claim/proof/trace artifacts (unless packaged into bundles separately)
 - TRACE-REPLAY-KIT execution output (unless referenced in a bundle)
 - Cross-tenant bundle aggregation
-- DSSE signature verification state beyond CERT `sig` field presence
+- DSSE signature verification state beyond CERT `sig` field presence (see [attestation signatures](../specs/evidence-attestation-signatures.md))
 
 ## What validation proves
 

--- a/docs/roadmap/evidence-program-closure.md
+++ b/docs/roadmap/evidence-program-closure.md
@@ -20,6 +20,8 @@ Every workflow under `.github/workflows/` that triggers on **`push` to `main`** 
 scripts/ci_workflow_inventory.sh
 ```
 
+**Current posture (2026-06-16):** The Evidence lane is implemented with documented green smoke baselines (see inventory table below). The repository is **not** fully green repo-wide — latest inventory on `main` reports **8/67** gated workflows green (exit 1). Do not claim full CI green in release communications until inventory exits 0.
+
 Reusable-only workflows (`workflow_call`) are tracked but not gating until invoked.
 
 ## Closure PR stack (2026-06-16)
@@ -63,6 +65,8 @@ Setup steps: [CONTRIBUTING.md](https://github.com/SentinelOps-CI/provability-fab
 | Post-#128 (`de104223`) | 67 | 8 | 56 | 21 |
 
 `scripts/ci_workflow_inventory.sh` on `main` after **#128** merge: **exit 1** (full-green criterion not met). Gains include `proto-compat.yaml` success; remaining red lanes are path-filtered push failures, optional AWS/Morph secrets, and infra-heavy Kind/Litmus jobs. Post-#128 ceremony dispatches: Evidence smoke [27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269), CI [27616317486](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616317486).
+
+Deep replay acceptance archive (private, local): `private/mou-evidence/acceptance-2026-06-16/evidence-v02-replay-report.json` — excerpt `status: pass`, `execute_status: pass`, `low_view_result: pass` (regenerated on maintainer host 2026-06-16; gitignored).
 
 Use Git Bash on Windows (`export PATH="/c/Program Files/GitHub CLI:$PATH"`) — WSL `bash` may not see `gh`.
 

--- a/docs/roadmap/evidence-v0.2-delivery.md
+++ b/docs/roadmap/evidence-v0.2-delivery.md
@@ -62,6 +62,17 @@ Gates align with the [Evidence v0.2 definition of done](evidence-v0.2.md#definit
 
 Green baselines: PR #110 (first full matrix after testbed fix), PR #111 (`main` workflow_dispatch [27512113090](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27512113090)), post-#116 [27527807232](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27527807232), post-#118 dispatch [27596580912](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596580912).
 
+## MoU replay deliverable mapping
+
+| MoU replay tier | PRs | Mechanism |
+|-----------------|-----|-----------|
+| v0.1 static / digest replay | #92–#95, #97 | `pf evidence replay` without `--execute`; trace digest + artifact binding |
+| v0.2 KIT import | #99 | `pf evidence trace import --kit-trace` |
+| v0.2 schema + `replay_context` | #100 | v0.2 bundle schema; strict path validation |
+| v0.2 deep execute + low-view | #101, #105 | `pf evidence replay --execute --low-view` via TRACE-REPLAY-KIT |
+
+PR **#92** introduced v0.1 static replay only. MoU deep-replay deliverables cite **#99–#101** and **#105**, not #92 alone.
+
 ## Fresh-clone verification checklist
 
 Run once on a clean machine before opening Evidence PRs (record result in [Evidence v0.2 status](evidence-v0.2-status.md)):

--- a/docs/roadmap/evidence-v0.2-status.md
+++ b/docs/roadmap/evidence-v0.2-status.md
@@ -9,9 +9,36 @@ Completion tracker for the Evidence v0.2 integration workstream. Implementation 
 | Merge commit | `3f150b1569b8dd50061d57ed99f34aa4b8dfffe6` |
 | Post-merge smoke | [workflow_dispatch 27596580912](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596580912) |
 | Closure stack | #121–#128 (`ci/standards-parity` … `ci/post-closure-hotfixes`) |
-| Sign-off page | [evidence-program-closure.md](evidence-program-closure.md) (#127); hotfixes **#128** merged `de104223` |
+| Sign-off page | [evidence-program-closure.md](evidence-program-closure.md) (#127); hotfixes **#128** merged `de104223`; post-#128 sign-off **#129** merged `fdca37c4` |
 | Post-#128 ceremony | Smoke [27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269), CI [27616317486](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616317486) |
 | Phase 6 ceremony | Smoke [27597765777](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27597765777), CI [27597765883](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27597765883) |
+
+## External standards verification (2026-06-16)
+
+| Check | `main` SHA | Result |
+|-------|------------|--------|
+| `make dev-standards` | `fdca37c4` | **Pass** locally (CERT-V1 + TRACE-REPLAY-KIT submodules initialized) |
+| `make standards-pin-check` | `fdca37c4` | **Pass** locally — pins match `tools/standards/versions.json` |
+| CI smoke (`STANDARDS_GITHUB_TOKEN`) | `de104223` | **Pass** — [run 27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269) (`make submodules` in Linux CI) |
+
+Org secret `STANDARDS_GITHUB_TOKEN` is configured for CI; local clones use HTTPS submodule URLs when the token is not present.
+
+## Acceptance verification record (2026-06-16)
+
+Maintainer packet (private, gitignored): `private/mou-evidence/acceptance-2026-06-16/`
+
+| Gate | Local (`fdca37c4`) | CI authority |
+|------|-------------------|--------------|
+| `pf evidence validate` v0.1/v0.2 `--strict` | Pass | smoke job in 27616315269 |
+| `pf evidence replay --execute --low-view` | Pass (Windows; `PYTHONIOENCODING=utf-8`) | smoke job in 27616315269 |
+| `mkdocs build --strict` | Pass | Documentation Build on PR #129 |
+| Repo-wide inventory | exit 1 (8/67 gated green) | N/A — see [program closure](evidence-program-closure.md) |
+
+Deep replay report archived at `private/mou-evidence/acceptance-2026-06-16/evidence-v02-replay-report.json`.
+
+## CI inventory caveat
+
+Evidence smoke and standards-pin baselines are green. The repository is **not** fully green repo-wide — inventory on `main` post-#128: **8/67** gated workflows green (exit 1). See [evidence-program-closure.md](evidence-program-closure.md).
 
 ## Implementation (branch stack)
 

--- a/docs/specs/evidence-attestation-signatures.md
+++ b/docs/specs/evidence-attestation-signatures.md
@@ -1,0 +1,53 @@
+# Evidence attestation signatures
+
+Evidence bundles may include **attestation** role artifacts that reference signed claims (for example, a proof artifact digest). This document clarifies what `pf evidence validate` guarantees for signatures versus what requires external verification.
+
+## What the attestation artifact carries
+
+The v0.1 attestation schema (`specs/evidence/v0.1/schemas/attestation.schema.json`) requires:
+
+- `attestor` — identifier of the signing party
+- `signed_claim_ref` — digest-bound reference to another bundle artifact (role, path, media type, digest)
+- `signature` — opaque signature string
+
+Example fixtures use `demo-signature-placeholder` for walkthrough purposes. These are **not** production cryptographic signatures.
+
+## What `pf evidence validate` checks
+
+In `--strict` mode, the Evidence validator:
+
+1. Validates the attestation JSON against `attestation.schema.json`
+2. Verifies the attestation artifact digest matches the bundle manifest
+3. Confirms `signed_claim_ref` paths and digests match on-disk artifacts when those artifacts are present in the bundle
+
+The validator does **not**:
+
+- Parse or verify DSSE / COSE / JWT envelope formats
+- Validate CERT-V1 `sig` fields on referenced certs
+- Invoke cosign, OpenSSL, or CERT-V1 verifier tooling
+
+No `signature` verification hook exists in `core/evidence` today; adding one would be a separate feature with explicit algorithm and key-trust policy.
+
+## Delegated verification (recommended MoU wording)
+
+> Evidence bundles **package** attestation artifacts and bind them to claim digests. **Signature verification is delegated** to CERT-V1 tooling and organization-specific verifier policies. Demo placeholders in repository fixtures are illustrative only.
+
+### External verifiers
+
+| Artifact type | Verify with |
+|---------------|-------------|
+| CERT-V1 JSON (`application/vnd.cert-v1+json`) | CERT-V1 schema + DSSE verifier (submodule `external/CERT-V1`) |
+| Attestation `signature` over proof/claim | Organization attestor policy; not enforced by `pf evidence validate` |
+| PCS signed science-claim bundles | PCS `pf verify` / admission adapters (separate lane) |
+
+## Operational guidance
+
+1. Treat `pf evidence validate --strict` as **structural and digest integrity** for attestations.
+2. Run CERT-V1 verification on any packaged cert artifacts before trusting enforcement claims.
+3. Replace fixture placeholders with real signatures only in deployment-specific bundles; do not commit production keys to the public repository.
+
+## Related
+
+- [Runtime evidence boundaries](../guides/runtime-evidence-boundaries.md)
+- [Evidence compatibility matrix](evidence-compatibility.md)
+- [Replay guarantees](../guides/replay-guarantees.md)

--- a/docs/specs/evidence-compatibility.md
+++ b/docs/specs/evidence-compatibility.md
@@ -82,4 +82,29 @@ See also [Evidence lane guide](evidence-lane-guide.md).
 | Windows bash testbed | CI runs on `ubuntu-latest`; local Windows may skip live sidecar |
 | Missing submodules | `make dev-standards`; CI fails closed on Evidence smoke |
 | KIT tag `v1.0.0` pending upstream | Commit pins in `tools/standards/versions.json` + `standards-pin-check` |
-| Morph / PCS / CERT sig verification | Documented non-guarantees in replay guide |
+| Morph / PCS / CERT sig verification | Documented non-guarantees in [replay guide](../guides/replay-guarantees.md) and [attestation signatures](evidence-attestation-signatures.md) |
+| Proof semantic checking (Lean) | Structural + digest-bound only — see [Proof artifact semantics](#proof-artifact-semantics) |
+
+## Proof artifact semantics
+
+Evidence bundles may include **proof** role artifacts (`proof.schema.json`). In `--strict` mode, `pf evidence validate`:
+
+- Validates proof JSON against the proof schema
+- Verifies the proof artifact digest matches the bundle manifest entry
+- Ensures digest-bound cross-references (for example from attestation `signed_claim_ref`) are internally consistent
+
+Evidence validation does **not**:
+
+- Invoke Lean or any semantic proof checker
+- Establish theorem soundness, policy correctness, or admission verdicts
+- Replace PCS or Morph proof obligations
+
+### Recommended MoU wording
+
+> The Evidence lane validates proof artifacts **structurally and digest-bound**. It does **not** perform Lean semantic proof checking. Proof soundness remains an external obligation of the producing system and its verification toolchain.
+
+See also [Evidence attestation signatures](evidence-attestation-signatures.md) for signature delegation.
+
+## pf check-trace caveat
+
+`pf check-trace` only verifies that a `bundles/` directory exists in the working tree. It is **not** an Evidence bundle validator, traceability checker, or substitute for `pf evidence validate --strict`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
           - Model: specs/evidence-model-v0.1.md
           - Bundle format: specs/evidence-bundle-v0.1.md
           - Compatibility: specs/evidence-compatibility.md
+          - Attestation signatures: specs/evidence-attestation-signatures.md
           - Lane guide: specs/evidence-lane-guide.md
           - Walkthrough: guides/evidence-bundle-walkthrough.md
           - Replay guarantees: guides/replay-guarantees.md


### PR DESCRIPTION
## Summary
- Gitignore private acceptance evidence folder
- Document attestation signature delegation and proof artifact semantics
- Map replay acceptance deliverables to v0.2 PR stack (#99-#101, #105)
- Accurate CI inventory caveat (8/67 gated green, not repo-wide green)
- Record acceptance verification and standards-pin check on main

## Test plan
- [x] go test ./... in core/evidence
- [x] mkdocs build --strict