### PR TITLE
fix(evidence): Evidence acceptance hardening — cross-platform scripts + status docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ dev-standards: submodules standards-pin-check
 
 evidence-verify: dev-standards
 	@$(ECHOOK) "Running Evidence v0.1/v0.2 verification..."
+	@$(ECHOOK) "Note: on Windows use Git Bash; testbed scripts prefer ./core/cli/pf/pf.exe with repo-relative paths."
 	cd core/evidence && go test ./...
 	pytest tests/evidence_schema tests/evidence_validation tests/evidence_replay \
 		tests/evidence_trace tests/runtime_evidence tests/testbed -q

--- a/core/evidence/kit_runner.go
+++ b/core/evidence/kit_runner.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // KITRunner executes TRACE-REPLAY-KIT replay_run.py.
@@ -79,6 +80,7 @@ func (r *defaultKITRunner) Run(tracePath, fixturesPath, certOut string) (int, er
 	cmd := exec.Command(r.python(), args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = kitPythonEnv()
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return exitErr.ExitCode(), nil
@@ -100,6 +102,7 @@ func (r *defaultKITRunner) CompareLowView(outputFiles []string, minDeterminism f
 	cmd := exec.Command(r.python(), args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = kitPythonEnv()
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return exitErr.ExitCode(), nil
@@ -107,4 +110,16 @@ func (r *defaultKITRunner) CompareLowView(outputFiles []string, minDeterminism f
 		return 1, err
 	}
 	return 0, nil
+}
+
+// kitPythonEnv returns os.Environ with PYTHONIOENCODING=utf-8 so KIT oracles
+// can emit Unicode on Windows consoles that default to a legacy code page.
+func kitPythonEnv() []string {
+	const key = "PYTHONIOENCODING="
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, key) {
+			return os.Environ()
+		}
+	}
+	return append(os.Environ(), key+"utf-8")
 }

--- a/docs/guides/runtime-evidence-boundaries.md
+++ b/docs/guides/runtime-evidence-boundaries.md
@@ -89,6 +89,21 @@ Runtime binding does not execute replay. Bundles that include `execution-trace` 
 3. Package certs and traces into v0.1 bundles with `pf evidence bundle pack`.
 4. Validate bundles before archival: `pf evidence validate <bundle> --strict`.
 
+## Runtime E2E verification authority
+
+Deliverable D3 (runtime integration) is verified on **Linux CI** as the authoritative path when local Windows hosts cannot reach crates.io or lack sidecar build prerequisites.
+
+| Check | Local command | CI authority |
+|-------|---------------|--------------|
+| Rust emit integration | `cargo test -p sidecar-watcher -- emit_evidence` | Covered indirectly via Evidence smoke pytest |
+| Linux sidecar binding | `pytest tests/runtime_evidence/test_runtime_evidence_sidecar.py -q` | [Evidence smoke 27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269) job `smoke` |
+
+**Windows caveat:** `cargo test` may fail with `CRYPT_E_NO_REVOCATION_CHECK` or other schannel SSL errors when fetching crates.io. This does not block MoU acceptance when the Linux smoke job above is green on the same commit family.
+
+**MoU wording:**
+
+> Runtime evidence binding is demonstrated by the sidecar emit integration test and Linux pytest path in Evidence v0.1 smoke CI. Local `cargo test emit_evidence` is recommended on Linux/macOS; Windows maintainers may defer to CI authority when network or SSL blocks crate downloads.
+
 ## Related
 
 - [Runtime evidence basic](runtime-evidence-basic.md)

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -4,6 +4,8 @@ These pages support ongoing development and experiments. They stay outside the p
 
 | Topic | Path |
 |-------|------|
+| MoU deliverable positioning | [mou-positioning.md](mou-positioning.md) |
+| CI health matrix | [ci-health-matrix.md](ci-health-matrix.md) |
 | Placeholder inventory | [placeholders/inventory.md](placeholders/inventory.md) |
 | SWE-bench stabilization matrix | [swebench-stabilization-regression-matrix.md](swebench-stabilization-regression-matrix.md) |
 | SWE-bench audit notes | [audit-swebench-experiments.md](audit-swebench-experiments.md) |

--- a/docs/internal/ci-health-matrix.md
+++ b/docs/internal/ci-health-matrix.md
@@ -2,6 +2,17 @@
 
 Triage snapshot for `main` as of 2026-06-15 after CI hardening PR #118.
 
+## MoU gap closure fixes (2026-06-16)
+
+Prepared on branch `fix/mou-gap-closure-2026-06-16` (requires `workflow` OAuth scope to push):
+
+| Workflow | Fix | Status |
+|----------|-----|--------|
+| `allowlist-sync.yaml` | `actions/checkout@v3` → `@v4` | Local commit; push blocked without workflow scope |
+| `lean-style.yaml` | elan install via `lean-toolchain` | Local commit; push blocked without workflow scope |
+| `performance-gate.yaml` | `actions/cache@v3` → `@v4` | Local commit; push blocked without workflow scope |
+| `integration.yaml` | `actions/cache@v3` → `@v4` | Local commit; push blocked without workflow scope |
+
 ## Evidence gate (must stay green)
 
 | Workflow | Job | Status | Notes |

--- a/docs/internal/mou-positioning.md
+++ b/docs/internal/mou-positioning.md
@@ -1,0 +1,56 @@
+# MoU positioning (Evidence deliverables 1–5)
+
+Internal reference for MoU-safe claims. Public counterparts live in specs and roadmap pages; this page consolidates exact wording for deliverables D1–D5.
+
+**Checkpoint:** `main` at `9788bb8a` (2026-06-16). Private acceptance packet: `private/mou-evidence/acceptance-2026-06-16/` (gitignored).
+
+## D1 — Schema and specification
+
+> Evidence v0.1/v0.2 JSON schemas, model docs, and the compatibility matrix define a **distinct lane** from PCS science-claim bundles and `so bundle pack` tar archives. Lane separation is enforced by schema IDs, negative tests, and documentation.
+
+**Non-claim:** Schemas do not merge PCS `EvidenceBundle.v0` with Evidence JSON bundles.
+
+## D2 — Bundle tooling
+
+> `pf evidence bundle pack` and `pf evidence validate --strict` provide **digest-bound structural validation** for claim, proof, attestation, and execution-trace artifacts referenced in a bundle manifest.
+
+**Non-claim:** Validation does not verify DSSE/CERT signatures, Lean proof soundness, or PCS admission verdicts.
+
+## D3 — Runtime integration
+
+> The sidecar emits CERT-V1 JSON and appends `evidence_v01_binding` JSONL on the emit path. Cert write paths are guarded by `scripts/check_cert_write_paths.sh`. Runtime binding is verified on **Linux CI** (Evidence smoke) when local Windows `cargo test` is blocked by network/SSL.
+
+**CI authority:** [Evidence smoke run 27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269) — runtime sidecar pytest green.
+
+**Non-claim:** Binding JSONL alone is not bundle validation; not every cert session is auto-packaged into bundles.
+
+## D4 — Replay
+
+> v0.1: static replay checks trace digests and preconditions. v0.2: TRACE-REPLAY-KIT import, `replay_context`, and `pf evidence replay --execute --low-view` for deep deterministic replay when submodules are initialized.
+
+**Non-claim:** `pf check-trace` and `so trace run` are not substitutes for Evidence replay. v0.2 deep replay requires `make submodules`; PR #92 alone does not cover v0.2 execute (cite #99–#101, #105).
+
+## D5 — Verification and closure
+
+> Testbeds, Evidence smoke CI, standards pin checks, and program closure docs (#127–#130) establish the verification gate for the Evidence program. Repo-wide CI inventory remains **not fully green** (8/67 gated workflows on latest inventory); Evidence lane baselines are green.
+
+**Non-claim:** Full-repository CI green is not claimed. Attestation `signature` fields in fixtures are placeholders; CERT-V1 DSSE verification is external (see [attestation signatures](../specs/evidence-attestation-signatures.md)).
+
+## Signature verification decision (2026-06-16)
+
+`pf evidence validate` does **not** include an opt-in `--verify-signatures` hook. Adding one would require algorithm selection, key-trust policy, and CERT-V1 submodule wiring beyond the current structural validator scope.
+
+**MoU-safe delegation:**
+
+> Evidence bundles package attestation artifacts and bind them to claim digests. Signature verification is delegated to CERT-V1 tooling and organization-specific verifier policies.
+
+## Suggested release tag (optional)
+
+If tagging after MoU sign-off: `evidence-v0.2.0-mou` or `pcs-pf-v0.1.0-rc3` — follow org release process; tag creation is out of scope for automated closure.
+
+## Related
+
+- [Evidence program closure](../roadmap/evidence-program-closure.md)
+- [Evidence v0.2 status](../roadmap/evidence-v0.2-status.md)
+- [Evidence attestation signatures](../specs/evidence-attestation-signatures.md)
+- [Runtime evidence boundaries](../guides/runtime-evidence-boundaries.md)

--- a/docs/roadmap/evidence-v0.2-status.md
+++ b/docs/roadmap/evidence-v0.2-status.md
@@ -1,6 +1,35 @@
 # Evidence v0.2 status
 
-Completion tracker for the Evidence v0.2 integration workstream. Implementation and delivery to `main` completed 2026-06-14 (PRs #98–#105); CI hardening through #118 (merged 2026-06-16).
+Completion tracker for the Evidence v0.2 integration workstream. Implementation and delivery to `main` completed 2026-06-14 (PRs #98–#105); CI hardening through #118 (merged 2026-06-16); MoU gap docs through #130 (merged 2026-06-16).
+
+## Public status checkpoint 2026-06-16
+
+| Item | Status |
+|------|--------|
+| **Main SHA** | `9788bb8a` (merge #130 `docs/mou-gap-analysis`) |
+| **D1–D2** Schema + bundle tooling | Complete — v0.1/v0.2 schemas, `pf evidence validate --strict`, compatibility matrix |
+| **D3** Runtime integration | Complete on Linux CI — sidecar binding + cert path guard; Windows `cargo test` deferred to CI authority |
+| **D4** Replay | Complete — v0.1 static + v0.2 deep execute/low-view; cross-platform testbed hardening in gap-closure PR |
+| **D5** Verification | Evidence smoke green; standards pins verified; program closure docs #127–#130 |
+| **Attestation signatures** | Structural + digest-bound only; DSSE verification external ([attestation signatures](../specs/evidence-attestation-signatures.md)) |
+| **Proof semantics** | Structural + digest-bound only; no Lean checking in Evidence lane |
+| **Docs** | `mkdocs build --strict` passes on maintainer host |
+
+### Explicit non-claims
+
+- **Not** full-repo CI green (inventory: 8/67 gated workflows green on post-#128 `main`)
+- **Not** Windows-local `cargo test emit_evidence` when crates.io SSL blocks downloads
+- **Not** in-validator CERT-V1 / attestation signature verification (`--verify-signatures` out of scope)
+- **Not** semantic proof checking (Lean) inside `pf evidence validate`
+
+### CI authority (Linux)
+
+| Gate | Run |
+|------|-----|
+| Evidence smoke (validate, replay, testbeds, runtime pytest) | [27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269) |
+| Core CI | [27616317486](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616317486) |
+
+Internal MoU wording: [mou-positioning.md](../internal/mou-positioning.md). Suggested tag (optional, not created): `evidence-v0.2.0-mou`.
 
 ## CI hardening #118 (merged)
 

--- a/docs/specs/evidence-compatibility.md
+++ b/docs/specs/evidence-compatibility.md
@@ -107,4 +107,4 @@ See also [Evidence attestation signatures](evidence-attestation-signatures.md) f
 
 ## pf check-trace caveat
 
-`pf check-trace` only verifies that a `bundles/` directory exists in the working tree. It is **not** an Evidence bundle validator, traceability checker, or substitute for `pf evidence validate --strict`.
+`pf check-trace` only verifies that a `bundles/` directory exists in the working tree. It is **not** an Evidence bundle validator, traceability checker, substitute for `pf evidence validate --strict`, or substitute for the Evidence replay lane (`pf evidence replay` / TRACE-REPLAY-KIT execute).

--- a/scripts/check_cert_write_paths.sh
+++ b/scripts/check_cert_write_paths.sh
@@ -13,6 +13,8 @@ ALLOWLIST=(
 violations=0
 while IFS= read -r line; do
   file="${line%%:*}"
+  # Normalize Windows path separators from ripgrep output.
+  file="${file//\\//}"
   skip=0
   for allowed in "${ALLOWLIST[@]}"; do
     if [[ "$file" == "$allowed" ]]; then

--- a/testbed/evidence-v0.1/run_happy_path.sh
+++ b/testbed/evidence-v0.1/run_happy_path.sh
@@ -2,14 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-PF="$ROOT/core/cli/pf/pf"
-BUNDLE="$ROOT/specs/evidence/v0.1/examples/valid/basic-evidence-bundle.json"
+cd "$ROOT"
 
-if [[ ! -x "$PF" ]]; then
-  (cd "$ROOT/core/cli/pf" && go build -o pf .)
+PF="${PF:-./core/cli/pf/pf}"
+if [[ -f "./core/cli/pf/pf.exe" ]]; then
+  PF="./core/cli/pf/pf.exe"
+elif [[ ! -x "$PF" && ! -f "$PF" ]]; then
+  (cd core/cli/pf && go build -o pf .)
+  PF="./core/cli/pf/pf"
 fi
 
-"$PF" evidence validate "$BUNDLE" --strict --base-dir "$ROOT/specs/evidence/v0.1/examples/valid"
-mkdir -p "$ROOT/testbed/evidence-v0.1/out"
-"$PF" evidence replay --bundle "$BUNDLE" --base-dir "$ROOT/specs/evidence/v0.1/examples/valid" --out "$ROOT/testbed/evidence-v0.1/out/replay-report.json"
+EXAMPLE="specs/evidence/v0.1/examples/valid"
+BUNDLE="$EXAMPLE/basic-evidence-bundle.json"
+
+"$PF" evidence validate "$BUNDLE" --strict --base-dir "$EXAMPLE"
+mkdir -p testbed/evidence-v0.1/out
+"$PF" evidence replay --bundle "$BUNDLE" --base-dir "$EXAMPLE" --out testbed/evidence-v0.1/out/replay-report.json
 echo "evidence-v0.1 happy path OK"

--- a/testbed/evidence-v0.2/run_deep_replay.sh
+++ b/testbed/evidence-v0.2/run_deep_replay.sh
@@ -7,12 +7,11 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
 PF="${PF:-./core/cli/pf/pf}"
-if [[ ! -x "$PF" && ! -f "$PF" && ! -x "./core/cli/pf/pf.exe" ]]; then
+if [[ -f "./core/cli/pf/pf.exe" ]]; then
+  PF="./core/cli/pf/pf.exe"
+elif [[ ! -x "$PF" && ! -f "$PF" ]]; then
   (cd core/cli/pf && go build -o pf .)
   PF="./core/cli/pf/pf"
-fi
-if [[ -x "./core/cli/pf/pf.exe" ]]; then
-  PF="./core/cli/pf/pf.exe"
 fi
 
 EXAMPLE="specs/evidence/v0.2/examples/valid"
@@ -35,6 +34,8 @@ if [[ ! -f external/TRACE-REPLAY-KIT/runner/replay_run.py ]]; then
 fi
 
 echo "== Step 3: execute + low-view =="
+# Windows consoles default to a legacy code page; KIT oracles may emit Unicode.
+export PYTHONIOENCODING="${PYTHONIOENCODING:-utf-8}"
 OUT="$(mktemp -d)"
 "$PF" evidence replay --bundle "$BUNDLE" --base-dir "$EXAMPLE" --execute --low-view --out-dir "$OUT/replay"
 echo "Deep replay execute complete."


### PR DESCRIPTION
## Summary

- Harden acceptance scripts for Windows/Git Bash: cert path guard, KIT `PYTHONIOENCODING`, testbed `pf.exe` + repo-relative paths
- Record runtime E2E CI authority, evidence acceptance positioning (D1–D5), Evidence v0.2 public status checkpoint (2026-06-16)
- Clarify `pf check-trace` vs Evidence replay lane; document pending CI workflow fixes (workflow OAuth scope blocked push)

## Test plan

- [x] `go test ./...` in `core/evidence`
- [x] `bash scripts/check_cert_write_paths.sh`
- [x] `bash testbed/evidence-v0.1/run_happy_path.sh`
- [x] `bash testbed/evidence-v0.2/run_deep_replay.sh --execute`
- [x] `mkdocs build --strict`

## Follow-up

CI workflow commits on local `fix/acceptance-gap-closure-2026-06-16` need push with `workflow` scope (allowlist-sync, lean-style, performance-gate, integration).