### PR TITLE
docs: sanitize public Evidence acceptance terminology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,6 +268,6 @@ workspaces_verify_preflight_smoke/
 
 core/cli/pf/pf
 
-# Private MoU evidence packets (local only; never commit)
+# Private acceptance evidence packets (local only; never commit)
 private/
 

--- a/docs/guides/runtime-evidence-boundaries.md
+++ b/docs/guides/runtime-evidence-boundaries.md
@@ -98,9 +98,9 @@ Deliverable D3 (runtime integration) is verified on **Linux CI** as the authorit
 | Rust emit integration | `cargo test -p sidecar-watcher -- emit_evidence` | Covered indirectly via Evidence smoke pytest |
 | Linux sidecar binding | `pytest tests/runtime_evidence/test_runtime_evidence_sidecar.py -q` | [Evidence smoke 27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269) job `smoke` |
 
-**Windows caveat:** `cargo test` may fail with `CRYPT_E_NO_REVOCATION_CHECK` or other schannel SSL errors when fetching crates.io. This does not block MoU acceptance when the Linux smoke job above is green on the same commit family.
+**Windows caveat:** `cargo test` may fail with `CRYPT_E_NO_REVOCATION_CHECK` or other schannel SSL errors when fetching crates.io. This does not block evidence acceptance when the Linux smoke job above is green on the same commit family.
 
-**MoU wording:**
+**Acceptance wording:**
 
 > Runtime evidence binding is demonstrated by the sidecar emit integration test and Linux pytest path in Evidence v0.1 smoke CI. Local `cargo test emit_evidence` is recommended on Linux/macOS; Windows maintainers may defer to CI authority when network or SSL blocks crate downloads.
 

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -4,7 +4,7 @@ These pages support ongoing development and experiments. They stay outside the p
 
 | Topic | Path |
 |-------|------|
-| MoU deliverable positioning | [mou-positioning.md](mou-positioning.md) |
+| Evidence acceptance positioning | [evidence-acceptance-positioning.md](evidence-acceptance-positioning.md) |
 | CI health matrix | [ci-health-matrix.md](ci-health-matrix.md) |
 | Placeholder inventory | [placeholders/inventory.md](placeholders/inventory.md) |
 | SWE-bench stabilization matrix | [swebench-stabilization-regression-matrix.md](swebench-stabilization-regression-matrix.md) |

--- a/docs/internal/ci-health-matrix.md
+++ b/docs/internal/ci-health-matrix.md
@@ -2,9 +2,9 @@
 
 Triage snapshot for `main` as of 2026-06-15 after CI hardening PR #118.
 
-## MoU gap closure fixes (2026-06-16)
+## Evidence acceptance gap closure fixes (2026-06-16)
 
-Prepared on branch `fix/mou-gap-closure-2026-06-16` (requires `workflow` OAuth scope to push):
+Prepared on branch `fix/acceptance-gap-closure-2026-06-16` (requires `workflow` OAuth scope to push):
 
 | Workflow | Fix | Status |
 |----------|-----|--------|

--- a/docs/internal/evidence-acceptance-positioning.md
+++ b/docs/internal/evidence-acceptance-positioning.md
@@ -1,8 +1,8 @@
-# MoU positioning (Evidence deliverables 1–5)
+# Evidence acceptance positioning (deliverables 1–5)
 
-Internal reference for MoU-safe claims. Public counterparts live in specs and roadmap pages; this page consolidates exact wording for deliverables D1–D5.
+Internal reference for acceptance-safe claims. Public counterparts live in specs and roadmap pages; this page consolidates exact wording for deliverables D1–D5.
 
-**Checkpoint:** `main` at `9788bb8a` (2026-06-16). Private acceptance packet: `private/mou-evidence/acceptance-2026-06-16/` (gitignored).
+**Checkpoint:** `main` at `9788bb8a` (2026-06-16). Private acceptance packet: `private/acceptance-evidence/acceptance-2026-06-16/` (gitignored).
 
 ## D1 — Schema and specification
 
@@ -40,13 +40,13 @@ Internal reference for MoU-safe claims. Public counterparts live in specs and ro
 
 `pf evidence validate` does **not** include an opt-in `--verify-signatures` hook. Adding one would require algorithm selection, key-trust policy, and CERT-V1 submodule wiring beyond the current structural validator scope.
 
-**MoU-safe delegation:**
+**Acceptance-safe delegation:**
 
 > Evidence bundles package attestation artifacts and bind them to claim digests. Signature verification is delegated to CERT-V1 tooling and organization-specific verifier policies.
 
 ## Suggested release tag (optional)
 
-If tagging after MoU sign-off: `evidence-v0.2.0-mou` or `pcs-pf-v0.1.0-rc3` — follow org release process; tag creation is out of scope for automated closure.
+If tagging after evidence acceptance sign-off: `evidence-v0.2.0-acceptance` or `pcs-pf-v0.1.0-rc3` — follow org release process; tag creation is out of scope for automated closure.
 
 ## Related
 

--- a/docs/roadmap/evidence-program-closure.md
+++ b/docs/roadmap/evidence-program-closure.md
@@ -66,7 +66,7 @@ Setup steps: [CONTRIBUTING.md](https://github.com/SentinelOps-CI/provability-fab
 
 `scripts/ci_workflow_inventory.sh` on `main` after **#128** merge: **exit 1** (full-green criterion not met). Gains include `proto-compat.yaml` success; remaining red lanes are path-filtered push failures, optional AWS/Morph secrets, and infra-heavy Kind/Litmus jobs. Post-#128 ceremony dispatches: Evidence smoke [27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269), CI [27616317486](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616317486).
 
-Deep replay acceptance archive (private, local): `private/mou-evidence/acceptance-2026-06-16/evidence-v02-replay-report.json` — excerpt `status: pass`, `execute_status: pass`, `low_view_result: pass` (regenerated on maintainer host 2026-06-16; gitignored).
+Deep replay acceptance archive (private, local): `private/acceptance-evidence/acceptance-2026-06-16/evidence-v02-replay-report.json` — excerpt `status: pass`, `execute_status: pass`, `low_view_result: pass` (regenerated on maintainer host 2026-06-16; gitignored).
 
 Use Git Bash on Windows (`export PATH="/c/Program Files/GitHub CLI:$PATH"`) — WSL `bash` may not see `gh`.
 

--- a/docs/roadmap/evidence-v0.2-delivery.md
+++ b/docs/roadmap/evidence-v0.2-delivery.md
@@ -62,16 +62,16 @@ Gates align with the [Evidence v0.2 definition of done](evidence-v0.2.md#definit
 
 Green baselines: PR #110 (first full matrix after testbed fix), PR #111 (`main` workflow_dispatch [27512113090](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27512113090)), post-#116 [27527807232](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27527807232), post-#118 dispatch [27596580912](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596580912).
 
-## MoU replay deliverable mapping
+## Replay acceptance deliverable mapping
 
-| MoU replay tier | PRs | Mechanism |
+| Replay acceptance tier | PRs | Mechanism |
 |-----------------|-----|-----------|
 | v0.1 static / digest replay | #92–#95, #97 | `pf evidence replay` without `--execute`; trace digest + artifact binding |
 | v0.2 KIT import | #99 | `pf evidence trace import --kit-trace` |
 | v0.2 schema + `replay_context` | #100 | v0.2 bundle schema; strict path validation |
 | v0.2 deep execute + low-view | #101, #105 | `pf evidence replay --execute --low-view` via TRACE-REPLAY-KIT |
 
-PR **#92** introduced v0.1 static replay only. MoU deep-replay deliverables cite **#99–#101** and **#105**, not #92 alone.
+PR **#92** introduced v0.1 static replay only. Deep-replay acceptance deliverables cite **#99–#101** and **#105**, not #92 alone.
 
 ## Fresh-clone verification checklist
 

--- a/docs/roadmap/evidence-v0.2-status.md
+++ b/docs/roadmap/evidence-v0.2-status.md
@@ -1,12 +1,12 @@
 # Evidence v0.2 status
 
-Completion tracker for the Evidence v0.2 integration workstream. Implementation and delivery to `main` completed 2026-06-14 (PRs #98–#105); CI hardening through #118 (merged 2026-06-16); MoU gap docs through #130 (merged 2026-06-16).
+Completion tracker for the Evidence v0.2 integration workstream. Implementation and delivery to `main` completed 2026-06-14 (PRs #98–#105); CI hardening through #118 (merged 2026-06-16); evidence acceptance gap docs through #130 (merged 2026-06-16).
 
 ## Public status checkpoint 2026-06-16
 
 | Item | Status |
 |------|--------|
-| **Main SHA** | `9788bb8a` (merge #130 `docs/mou-gap-analysis`) |
+| **Main SHA** | `9788bb8a` (merge #130 evidence acceptance gap analysis) |
 | **D1–D2** Schema + bundle tooling | Complete — v0.1/v0.2 schemas, `pf evidence validate --strict`, compatibility matrix |
 | **D3** Runtime integration | Complete on Linux CI — sidecar binding + cert path guard; Windows `cargo test` deferred to CI authority |
 | **D4** Replay | Complete — v0.1 static + v0.2 deep execute/low-view; cross-platform testbed hardening in gap-closure PR |
@@ -29,7 +29,7 @@ Completion tracker for the Evidence v0.2 integration workstream. Implementation 
 | Evidence smoke (validate, replay, testbeds, runtime pytest) | [27616315269](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616315269) |
 | Core CI | [27616317486](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27616317486) |
 
-Internal MoU wording: [mou-positioning.md](../internal/mou-positioning.md). Suggested tag (optional, not created): `evidence-v0.2.0-mou`.
+Internal evidence acceptance positioning: [evidence-acceptance-positioning.md](../internal/evidence-acceptance-positioning.md). Suggested tag (optional, not created): `evidence-v0.2.0-acceptance`.
 
 ## CI hardening #118 (merged)
 
@@ -54,7 +54,7 @@ Org secret `STANDARDS_GITHUB_TOKEN` is configured for CI; local clones use HTTPS
 
 ## Acceptance verification record (2026-06-16)
 
-Maintainer packet (private, gitignored): `private/mou-evidence/acceptance-2026-06-16/`
+Maintainer packet (private, gitignored): `private/acceptance-evidence/acceptance-2026-06-16/`
 
 | Gate | Local (`fdca37c4`) | CI authority |
 |------|-------------------|--------------|
@@ -63,7 +63,7 @@ Maintainer packet (private, gitignored): `private/mou-evidence/acceptance-2026-0
 | `mkdocs build --strict` | Pass | Documentation Build on PR #129 |
 | Repo-wide inventory | exit 1 (8/67 gated green) | N/A — see [program closure](evidence-program-closure.md) |
 
-Deep replay report archived at `private/mou-evidence/acceptance-2026-06-16/evidence-v02-replay-report.json`.
+Deep replay report archived at `private/acceptance-evidence/acceptance-2026-06-16/evidence-v02-replay-report.json`.
 
 ## CI inventory caveat
 

--- a/docs/specs/evidence-attestation-signatures.md
+++ b/docs/specs/evidence-attestation-signatures.md
@@ -28,7 +28,7 @@ The validator does **not**:
 
 No `signature` verification hook exists in `core/evidence` today; adding one would be a separate feature with explicit algorithm and key-trust policy.
 
-## Delegated verification (recommended MoU wording)
+## Delegated verification (recommended acceptance wording)
 
 > Evidence bundles **package** attestation artifacts and bind them to claim digests. **Signature verification is delegated** to CERT-V1 tooling and organization-specific verifier policies. Demo placeholders in repository fixtures are illustrative only.
 

--- a/docs/specs/evidence-compatibility.md
+++ b/docs/specs/evidence-compatibility.md
@@ -99,7 +99,7 @@ Evidence validation does **not**:
 - Establish theorem soundness, policy correctness, or admission verdicts
 - Replace PCS or Morph proof obligations
 
-### Recommended MoU wording
+### Recommended acceptance wording
 
 > The Evidence lane validates proof artifacts **structurally and digest-bound**. It does **not** perform Lean semantic proof checking. Proof soundness remains an external obligation of the producing system and its verification toolchain.
 


### PR DESCRIPTION
## Summary
- Rename `docs/internal/mou-positioning.md` to `evidence-acceptance-positioning.md` and replace MoU wording with Evidence acceptance terminology
- Sanitize roadmap, specs, guides, and internal docs; update `.gitignore` comment for `private/acceptance-evidence`
- No changes under `private/` (local folder renamed only)

## Test plan
- [x] `mkdocs build --strict`
- [x] `grep -ri mou docs/ .gitignore mkdocs.yml` — zero MoU hits (only false positives: Anonymous, mount)
