### PR TITLE
ci: gap-closure workflow bumps (checkout/cache v4, lean elan)

### DIFF
--- a/.github/workflows/allowlist-sync.yaml
+++ b/.github/workflows/allowlist-sync.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -44,7 +44,7 @@ jobs:
           version: v3.12.0
 
       - name: Cache Kind images
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.kind

--- a/.github/workflows/lean-style.yaml
+++ b/.github/workflows/lean-style.yaml
@@ -24,10 +24,14 @@ jobs:
         with:
           fetch-depth: 0  # Full history for git operations
 
-      - name: Set up Lean
+      - name: Set up Lean (elan)
         run: |
-          curl -L https://github.com/leanprover/lean4/releases/download/v4.7.0/lean-4.7.0-linux.tar.gz | tar -xz
-          echo "$PWD/lean-4.7.0-linux/bin" >> $GITHUB_PATH
+          curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+          TOOLCHAIN=$(tr -d '\n\r' < lean-toolchain)
+          "$HOME/.elan/bin/elan" toolchain install "$TOOLCHAIN"
+          "$HOME/.elan/bin/elan" override set "$TOOLCHAIN"
+          lean --version
 
       - name: Make duplicate check script executable
         run: |

--- a/.github/workflows/performance-gate.yaml
+++ b/.github/workflows/performance-gate.yaml
@@ -42,7 +42,7 @@ jobs:
           profile: minimal
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## Summary
- ci(allowlist-sync): bump checkout action to v4
- ci(lean-style): install Lean via elan and lean-toolchain
- ci(performance-gate): bump actions/cache to v4
- ci(integration): bump actions/cache to v4
- docs(internal): track fixes in ci-health-matrix

Five separate commits preserved (no squash).

## Test plan
- [ ] allowlist-sync, lean-style, performance-gate, integration workflows green on PR
- [ ] Evidence lane unchanged