### PR TITLE
Remove 'Provability Fabric' header

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
 ##############################################################################################
 </pre>
 
-# Provability Fabric
-
 **Formal guarantees for agent behavior** — proofs, runtime guards, and auditable evidence in one open stack.
 
 <sub>Prove · Enforce · Audit — formal specs, runtime policy, and evidence on one track.</sub>


### PR DESCRIPTION
Removed the 'Provability Fabric' header from the README.