### PR TITLE
Phase 7 PR-3: pf core CLI wrapper

### DIFF
--- a/core/cli/pf/main.go
+++ b/core/cli/pf/main.go
@@ -59,6 +59,7 @@ func init() {
 	rootCmd.AddCommand(sign)
 	pfcmd.RegisterScienceClaimSign(sign)
 	pfcmd.RegisterPCSCommands(rootCmd)
+	rootCmd.AddCommand(pfCoreCmd())
 	rootCmd.AddCommand(checkTraceCmd())
 	rootCmd.AddCommand(watchCmd())
 	rootCmd.AddCommand(riskscoreCmd())

--- a/core/cli/pf/pf_core_commands.go
+++ b/core/cli/pf/pf_core_commands.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func pfCoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "core",
+		Short: "PF-Core validator commands (compile-observation, check-trace, emit-certificate, emit-artifacts)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPfCoreCLI(args)
+		},
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:                "compile-observation",
+		Short:              "Compile runtime_observation.v1 to event.v1",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPfCoreCLI(append([]string{"core", "compile-observation"}, args...))
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:                "check-trace",
+		Short:              "Validate trace hash chain and safety deciders",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPfCoreCLI(append([]string{"core", "check-trace"}, args...))
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:                "emit-certificate",
+		Short:              "Emit pf-core.certificate.v0 for a trace",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPfCoreCLI(append([]string{"core", "emit-certificate"}, args...))
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:                "emit-artifacts",
+		Short:              "Emit five-file PF-Core artifact bundle",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPfCoreCLI(append([]string{"core", "emit-artifacts"}, args...))
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:                "schema-check",
+		Short:              "Validate PF-Core JSON schemas",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPfCoreCLI(append([]string{"core", "schema-check"}, args...))
+		},
+	})
+	return cmd
+}
+
+func runPfCoreCLI(args []string) error {
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+	script := filepath.Join(root, "scripts", "pf-core.sh")
+	if _, err := os.Stat(script); err != nil {
+		return fmt.Errorf("pf-core wrapper script missing: %w", err)
+	}
+	pyArgs := append([]string{script}, args...)
+	proc := exec.Command("bash", pyArgs...)
+	proc.Stdout = os.Stdout
+	proc.Stderr = os.Stderr
+	proc.Stdin = os.Stdin
+	if err := proc.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		return err
+	}
+	return nil
+}
+
+func repoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := wd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "scripts", "pf-core.sh")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return wd, nil
+		}
+		dir = parent
+	}
+}

--- a/scripts/pf-core.sh
+++ b/scripts/pf-core.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Delegate to pf-core-validator (Phase 7 PR-3).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PYTHON="${PYTHON:-python3}"
+export PYTHONPATH="${PYTHONPATH:-}:${ROOT}/tools/pf-core"
+exec "$PYTHON" -m pf_core.cli "$@"

--- a/scripts/test_pf_core_wrapper.sh
+++ b/scripts/test_pf_core_wrapper.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Smoke test pf core wrapper against pinned schemas (Phase 7 PR-3).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+bash "$ROOT/scripts/init_pf_core_vendor.sh"
+pip install -q -e "$ROOT/tools/pf-core" jsonschema referencing
+bash "$ROOT/scripts/pf-core.sh" core schema-check --schemas "$ROOT/vendor/pf-core/schemas"
+echo "OK: pf core wrapper schema-check"

--- a/tools/pf-core/README.md
+++ b/tools/pf-core/README.md
@@ -1,0 +1,22 @@
+# PF-Core CLI wrapper (Phase 7 PR-3)
+
+Install:
+
+```bash
+pip install -e tools/pf-core
+```
+
+Invoke (same surface as provability-fabric-core):
+
+```bash
+python -m pf_core_wrapper.cli core schema-check --schemas vendor/pf-core/schemas
+python -m pf_core.cli core compile-observation --schemas vendor/pf-core/schemas --file obs.json
+```
+
+Or via repo helper:
+
+```bash
+bash scripts/pf-core.sh core check-trace --schemas vendor/pf-core/schemas --file trace.json
+```
+
+The Go `pf` CLI exposes `pf core` as a subprocess bridge to this wrapper.

--- a/tools/pf-core/pf_core_wrapper/__init__.py
+++ b/tools/pf-core/pf_core_wrapper/__init__.py
@@ -1,0 +1,1 @@
+"""Provability-fabric PF-Core CLI wrapper."""

--- a/tools/pf-core/pf_core_wrapper/cli.py
+++ b/tools/pf-core/pf_core_wrapper/cli.py
@@ -1,0 +1,16 @@
+"""Delegate `pf core <command>` to pf-core-validator."""
+
+from __future__ import annotations
+
+import sys
+
+from pf_core.cli import main as pf_core_main
+
+
+def main() -> None:
+    """Entry point: expects argv like `core compile-observation ...`."""
+    pf_core_main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pf-core/pyproject.toml
+++ b/tools/pf-core/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "provability-fabric-pf-core-wrapper"
+version = "0.6.0"
+description = "Thin wrapper delegating to pf-core-validator (Phase 7 PR-3)"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "jsonschema>=4.0",
+  "referencing>=0.30",
+  "pf-core-validator @ git+https://github.com/SentinelOps-CI/provability-fabric-core.git@pf-core-v0.6.0#subdirectory=pf-core/validator",
+]
+
+[project.scripts]
+pf-core-validator = "pf_core_wrapper.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["pf_core_wrapper*"]

--- a/tools/pf-core/requirements.txt
+++ b/tools/pf-core/requirements.txt
@@ -1,0 +1,4 @@
+# PF-Core validator pin (Phase 7 PR-3)
+-e tools/pf-core
+jsonschema>=4.0
+referencing>=0.30


### PR DESCRIPTION
## Summary

- Add `tools/pf-core/` Python wrapper pinning `pf-core-v0.6.0` validator
- Add `scripts/pf-core.sh` and Go `pf core` subprocess bridge
- Smoke script `scripts/test_pf_core_wrapper.sh` runs schema-check

## Test plan

- [ ] `bash scripts/test_pf_core_wrapper.sh`
- [ ] `pf core schema-check --schemas vendor/pf-core/schemas`
- [ ] Wrapper passes mcp-sidecar compile-observation scenario