### PR TITLE
Phase 7 PR-4: Admission-controller audit line compatibility

### DIFF
--- a/.github/workflows/pf-core-schema-check.yml
+++ b/.github/workflows/pf-core-schema-check.yml
@@ -8,6 +8,8 @@ on:
       - "runtime/sidecar-watcher/**"
       - "vendor/pf-core/**"
       - "scripts/init_pf_core_vendor.sh"
+      - "scripts/test_admission_parity.sh"
+      - "tests/pf_core_admission_parity/**"
       - ".github/workflows/pf-core-schema-check.yml"
 
 jobs:
@@ -43,3 +45,8 @@ jobs:
         run: |
           cd runtime/sidecar-watcher
           cargo test --lib runtime_observation
+
+      - name: Admission audit normalize parity (PR-4)
+        env:
+          PF_CORE_REF: ${{ github.workspace }}/pf-core-ref
+        run: bash scripts/test_admission_parity.sh

--- a/docs/internal/ci-inventory-latest.md
+++ b/docs/internal/ci-inventory-latest.md
@@ -1,151 +1,92 @@
-﻿# CI workflow inventory (auto-generated)
+﻿CI workflow inventory - repo=SentinelOps-CI/provability-fabric branch=main
+WORKFLOW                                   TRIGGERS                     STATUS       URL
+--------------------------------------------------------------------------------------------------------------
+actionlint.yml                             push, pull_request           success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922330
+adapters-ci.yml                            push, pull_request           failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922311
+allowlist-sync.yaml                        push, pull_request           success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706271
+art-benchmark.yaml                         push, pull_request, schedule failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399502401
+bench-nightly-criterion.yaml               push, pull_request, schedule, workflow_dispatch in_progress* https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691442
+bench-swebench-smoke.yaml                  push, pull_request, schedule, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705704
+bench-swebench-stress-scheduled.yaml       schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28314414940
+bench-swebench-unit.yaml                   push, pull_request           failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576576
+billing-test.yaml                          push, pull_request, schedule failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922315
+bundle-check.yaml                          pull_request                 no_run       -
+cargo-deny.yml                             push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691406
+cert-validate.yml                          push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28625116959
+chaos-nightly.yaml                         schedule, workflow_dispatch  success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568878282
+ci.yml                                     push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691498
+ci-nightly-pytest.yml                      schedule, workflow_dispatch  success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28576040030
+ci-weekly-full.yml                         schedule, workflow_dispatch  success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28367886347
+cla-bot.yaml                               pull_request, workflow_dispatch failure      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27528984318
+codeql.yaml                                push, pull_request, schedule in_progress* https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691407
+compliance.yaml                            release, workflow_dispatch   no_run       -
+demo-e2e.yml                               push, pull_request           failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705589
+dependency-review.yml                      pull_request                 no_run       -
+dep-graph.yaml                             pull_request                 no_run       -
+dfa.yaml                                   push, pull_request           success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647153
+docs-build.yaml                            push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28625116934
+docs-deploy.yaml                           push                         success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28625116948
+dr-cross.yaml                              schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28313345565
+edge-load.yaml                             schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417787429
+egress.yml                                 push, pull_request, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705538
+evidence.yaml                              push, schedule, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28569079948
+evidence-v01-smoke.yml                     push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28625116975
+fuzz.yaml                                  push, pull_request           success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691416
+heartbeat-test.yaml                        pull_request, workflow_dispatch no_run       -
+incident-e2e.yaml                          workflow_dispatch            no_run       -
+incident-test.yaml                         push, pull_request, schedule failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399492108
+integration.yaml                           push, pull_request           failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691379
+jwks-validate.yml                          push, workflow_dispatch      success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705444
+lean-morph.yml                             push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922346
+lean-offline.yaml                          push, schedule, workflow_dispatch cancelled*   https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922294
+lean-style.yaml                            push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922304
+loadtest.yaml                              pull_request, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399924626
+marketplace-e2e.yaml                       push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705631
+morph-replay.yml                           push, workflow_dispatch      success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705516
+multiarch-build.yaml                       push, pull_request, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691412
+nightly-replay.yml                         schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568693881
+opa-test.yaml                              push, pull_request           failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/16584478677
+operational-excellence.yaml                push, pull_request, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691421
+paper-conformance.yaml                     push, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691431
+pcs-ci.yml                                 push, pull_request, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705524
+perf.yaml                                  schedule, workflow_dispatch  cancelled*   https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28569153198
+performance-gate.yaml                      push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705629
+perf-proofmeter.yaml                       push, pull_request, schedule failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417776889
+pf-ci.yaml                                 workflow_call                failure      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677070943
+pf-core-schema-check.yml                   push, pull_request           no_run*      -
+pf-cross-repo-consumer.yaml                pull_request, schedule       failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399838783
+pf-reusable-caller.yaml                    pull_request, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28572843688
+platform-cert-validate.yml                 push, pull_request, schedule, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705691
+platform-perf-smoke.yml                    push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922281
+platform-replay.yml                        push, pull_request, schedule, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705297
+policy-build.yml                           push, pull_request           success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647162
+policy-gates.yaml                          push, pull_request           success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691427
+policy-pr-proof.yml                        pull_request                 no_run       -
+pr-comments.yml                            pull_request                 no_run       -
+privacy-test.yaml                          push, pull_request, schedule success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691418
+proof-bot.yaml                             schedule, workflow_dispatch, issue_comment failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28589794992
+proof-fuzz.yaml                            push, pull_request, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399477882
+proto-compat.yaml                          push, pull_request, schedule failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706169
+publish-updates.yaml                       push, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399543888
+rbac-test.yaml                             pull_request, workflow_dispatch no_run       -
+redteam.yaml                               pull_request, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28312328896
+release.yaml                               push, workflow_dispatch      no_run*      -
+release-sbom.yml                           release                      no_run       -
+replay.yml                                 push, pull_request           success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705517
+retrieval-gateway.yml                      push, pull_request           success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922316
+reusable-ci-extended.yml                   workflow_call                no_run       -
+reusable-ci-go-node.yml                    workflow_call                no_run       -
+reusable-ci-lean.yml                       workflow_call                no_run       -
+reusable-ci-prepare.yml                    workflow_call                no_run       -
+reusable-ci-rust.yml                       workflow_call                no_run       -
+revocation-sync.yaml                       schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19400248470
+sbom-diff.yaml                             push, pull_request, release  success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691430
+scorecards.yml                             push, schedule, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28627691408
+slo-gates.yaml                             push, pull_request, schedule skipped*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647128
+spec-ai.yaml                               pull_request                 no_run       -
+standards-pin.yml                          push, pull_request, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28625116949
+trust-fire-ga-test.yaml                    schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28314313517
+verify-publish-bundle.yaml                 push, pull_request, workflow_dispatch no_run*      -
+wasm-scan.yaml                             push, pull_request           success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922329
 
-Generated: 2026-07-02T12:47:01Z UTC
-Repository: `SentinelOps-CI/provability-fabric` branch `main`
-
-## Summary
-
-| Metric | Count |
-|--------|------:|
-| Total workflow files | 86 |
-| Gated (push/schedule on main) | 68 |
-| Green (last run success) | 26 |
-| Red (failure/cancelled/in progress) | 42 |
-| No run / unknown | 18 |
-
-## Workflows
-
-| Workflow | Triggers | Last status | Gated | URL |
-|----------|----------|-------------|-------|-----|
-| `actionlint.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706332 |
-| `adapters-ci.yml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705475 |
-| `allowlist-sync.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706271 |
-| `art-benchmark.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399502401 |
-| `bench-nightly-criterion.yaml` | push, pull_request, schedule, workflow_dispatch | **in_progress** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585900934 |
-| `bench-swebench-smoke.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705704 |
-| `bench-swebench-stress-scheduled.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28314414940 |
-| `bench-swebench-unit.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576576 |
-| `billing-test.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399598636 |
-| `bundle-check.yaml` | pull_request | no_run | no | - |
-| `cargo-deny.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705316 |
-| `cert-validate.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705523 |
-| `chaos-nightly.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568878282 |
-| `ci.yml` | push, pull_request, workflow_dispatch | **in_progress** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705582 |
-| `ci-nightly-pytest.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28576040030 |
-| `ci-weekly-full.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28367886347 |
-| `cla-bot.yaml` | pull_request, workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27528984318 |
-| `codeql.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705418 |
-| `compliance.yaml` | release, workflow_dispatch | no_run | no | - |
-| `demo-e2e.yml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705589 |
-| `dependency-review.yml` | pull_request | no_run | no | - |
-| `dep-graph.yaml` | pull_request | no_run | no | - |
-| `dfa.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647153 |
-| `docs-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705338 |
-| `docs-deploy.yaml` | push | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705536 |
-| `dr-cross.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28313345565 |
-| `edge-load.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417787429 |
-| `egress.yml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705538 |
-| `evidence.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28569079948 |
-| `evidence-v01-smoke.yml` | push, pull_request, workflow_dispatch | **queued** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705539 |
-| `fuzz.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705323 |
-| `heartbeat-test.yaml` | pull_request, workflow_dispatch | no_run | no | - |
-| `incident-e2e.yaml` | workflow_dispatch | no_run | no | - |
-| `incident-test.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399492108 |
-| `integration.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706085 |
-| `jwks-validate.yml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705444 |
-| `lean-morph.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705506 |
-| `lean-offline.yaml` | push, schedule, workflow_dispatch | **in_progress** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705320 |
-| `lean-style.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706852 |
-| `loadtest.yaml` | pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399924626 |
-| `marketplace-e2e.yaml` | push, pull_request, workflow_dispatch | **queued** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705631 |
-| `morph-replay.yml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705516 |
-| `multiarch-build.yaml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705304 |
-| `nightly-replay.yml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568693881 |
-| `opa-test.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/16584478677 |
-| `operational-excellence.yaml` | push, pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399591865 |
-| `paper-conformance.yaml` | push, schedule, workflow_dispatch | **queued** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705694 |
-| `pcs-ci.yml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705524 |
-| `perf.yaml` | schedule, workflow_dispatch | **cancelled** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28569153198 |
-| `performance-gate.yaml` | push, pull_request, workflow_dispatch | **queued** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705629 |
-| `perf-proofmeter.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417776889 |
-| `pf-ci.yaml` | workflow_call | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677070943 |
-| `pf-cross-repo-consumer.yaml` | pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399838783 |
-| `pf-reusable-caller.yaml` | pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28572843688 |
-| `platform-cert-validate.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705691 |
-| `platform-perf-smoke.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706202 |
-| `platform-replay.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705297 |
-| `policy-build.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647162 |
-| `policy-gates.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585707156 |
-| `policy-pr-proof.yml` | pull_request | no_run | no | - |
-| `pr-comments.yml` | pull_request | no_run | no | - |
-| `privacy-test.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705511 |
-| `proof-bot.yaml` | schedule, workflow_dispatch, issue_comment | **queued** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28589794992 |
-| `proof-fuzz.yaml` | push, pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399477882 |
-| `proto-compat.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706169 |
-| `publish-updates.yaml` | push, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399543888 |
-| `rbac-test.yaml` | pull_request, workflow_dispatch | no_run | no | - |
-| `redteam.yaml` | pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28312328896 |
-| `release.yaml` | push, workflow_dispatch | **no_run** | yes | - |
-| `release-sbom.yml` | release | no_run | no | - |
-| `replay.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705517 |
-| `retrieval-gateway.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706166 |
-| `reusable-ci-extended.yml` | workflow_call | no_run | no | - |
-| `reusable-ci-go-node.yml` | workflow_call | no_run | no | - |
-| `reusable-ci-lean.yml` | workflow_call | no_run | no | - |
-| `reusable-ci-prepare.yml` | workflow_call | no_run | no | - |
-| `reusable-ci-rust.yml` | workflow_call | no_run | no | - |
-| `revocation-sync.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19400248470 |
-| `sbom-diff.yaml` | push, pull_request, release | **queued** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705575 |
-| `scorecards.yml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706992 |
-| `slo-gates.yaml` | push, pull_request, schedule | **skipped** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647128 |
-| `spec-ai.yaml` | pull_request | no_run | no | - |
-| `standards-pin.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705309 |
-| `trust-fire-ga-test.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28314313517 |
-| `verify-publish-bundle.yaml` | push, pull_request, workflow_dispatch | **no_run** | yes | - |
-| `wasm-scan.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705335 |
-
-## Gated workflows not green
-
-- `adapters-ci.yml (failure)`
-- `art-benchmark.yaml (failure)`
-- `bench-nightly-criterion.yaml (in_progress)`
-- `bench-swebench-stress-scheduled.yaml (failure)`
-- `bench-swebench-unit.yaml (failure)`
-- `billing-test.yaml (failure)`
-- `ci.yml (in_progress)`
-- `codeql.yaml (failure)`
-- `demo-e2e.yml (failure)`
-- `dr-cross.yaml (failure)`
-- `edge-load.yaml (failure)`
-- `egress.yml (failure)`
-- `evidence-v01-smoke.yml (queued)`
-- `incident-test.yaml (failure)`
-- `integration.yaml (failure)`
-- `lean-offline.yaml (in_progress)`
-- `loadtest.yaml (failure)`
-- `marketplace-e2e.yaml (queued)`
-- `multiarch-build.yaml (failure)`
-- `nightly-replay.yml (failure)`
-- `opa-test.yaml (failure)`
-- `operational-excellence.yaml (failure)`
-- `paper-conformance.yaml (queued)`
-- `pcs-ci.yml (failure)`
-- `perf.yaml (cancelled)`
-- `performance-gate.yaml (queued)`
-- `perf-proofmeter.yaml (failure)`
-- `pf-cross-repo-consumer.yaml (failure)`
-- `pf-reusable-caller.yaml (failure)`
-- `policy-gates.yaml (failure)`
-- `proof-bot.yaml (queued)`
-- `proof-fuzz.yaml (failure)`
-- `proto-compat.yaml (failure)`
-- `publish-updates.yaml (failure)`
-- `redteam.yaml (failure)`
-- `release.yaml (no_run)`
-- `revocation-sync.yaml (failure)`
-- `sbom-diff.yaml (queued)`
-- `slo-gates.yaml (skipped)`
-- `trust-fire-ga-test.yaml (failure)`
-- `verify-publish-bundle.yaml (no_run)`
-- `wasm-scan.yaml (failure)`
-
+Summary: total=87 gated(push/schedule)=69 green=33 red=35 unknown=19

--- a/runtime/sidecar-watcher/Cargo.toml
+++ b/runtime/sidecar-watcher/Cargo.toml
@@ -36,6 +36,10 @@ rand = "0.8"
 arc-swap = "1.6"
 parking_lot = "0.12"
 
+[[bin]]
+name = "emit_observation"
+path = "src/bin/emit_observation.rs"
+
 [dev-dependencies]
 tokio-test = "0.4"
 tempfile = "3"

--- a/runtime/sidecar-watcher/docs/PF_CORE_AUDIT_MAPPING.md
+++ b/runtime/sidecar-watcher/docs/PF_CORE_AUDIT_MAPPING.md
@@ -1,0 +1,40 @@
+# Sidecar / admission audit line → PF-Core runtime_observation.v1
+
+Phase 7 PR-4 field mapping. Admission-controller and sidecar-watcher emit the same audit JSON shape; native emission replaces the provability-fabric-core normalize shim.
+
+## Sidecar audit field → PF-Core v1
+
+| Audit field | PF-Core v1 field |
+|-------------|------------------|
+| `request_id` | `observation_id` |
+| `trace_id` | `trace_id` |
+| `event_id` | `event_id` |
+| `agent_id` | `principal.id` |
+| `tenant` | `principal.tenant_id` |
+| `tool_effect` | `action.effects[].kind` |
+| `resource` | `action.reads[].uri` |
+| `policy_decision` | `decision` |
+| `prev_hash` | `previous_event_hash` |
+| `policy_bundle` | `policy_ref` |
+| `audit_bundle` | `evidence_ref` |
+| `capability_hint` | `action.capability.id` |
+| `runtime_ref` | `runtime_ref` |
+| `timestamp` | `timestamp` |
+| `reason` | `reason` |
+
+Principal roles resolve from `fixtures/capability_catalog.json` (`principal_roles_by_capability`), not hardcoded.
+
+## Native emission
+
+```bash
+cat tests/fixtures/sidecar_audit_line.json | cargo run --bin emit_observation
+pf core compile-observation --schemas vendor/pf-core/schemas --file obs.json
+```
+
+## Parity gate
+
+```bash
+bash scripts/test_admission_parity.sh
+```
+
+Compares native Rust output to reference `adapters/provability-fabric/mcp_sidecar/normalize.py` on golden fixtures.

--- a/runtime/sidecar-watcher/src/bin/emit_observation.rs
+++ b/runtime/sidecar-watcher/src/bin/emit_observation.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 Provability-Fabric Contributors
+
+//! Emit pf-core.runtime_observation.v1 from a sidecar audit JSON line on stdin.
+
+use sidecar_watcher::runtime_observation::{default_catalog_path, emit_from_audit_json};
+use std::io::{self, Read};
+
+fn main() -> anyhow::Result<()> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    let obs = emit_from_audit_json(input.trim(), default_catalog_path())?;
+    println!("{}", serde_json::to_string_pretty(&obs)?);
+    Ok(())
+}

--- a/scripts/test_admission_parity.sh
+++ b/scripts/test_admission_parity.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Admission / sidecar audit parity vs reference normalize.py (Phase 7 PR-4).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PF_CORE_REF="${PF_CORE_REF:-$ROOT/../provability-fabric-core}"
+export PF_CORE_REF
+
+pip install -q pytest 2>/dev/null || python3 -m pip install -q pytest
+cd "$ROOT/runtime/sidecar-watcher"
+cargo build --quiet --bin emit_observation
+cd "$ROOT"
+PYTHONPATH="$PF_CORE_REF/pf-core/validator" pytest tests/pf_core_admission_parity/test_sidecar_normalize_parity.py -v
+echo "OK: admission/sidecar normalize parity"

--- a/tests/pf_core_admission_parity/test_sidecar_normalize_parity.py
+++ b/tests/pf_core_admission_parity/test_sidecar_normalize_parity.py
@@ -1,0 +1,146 @@
+"""Parity: native sidecar emitter vs reference normalize.py (Phase 7 PR-4)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PF_CORE_ROOT = Path(
+    os.environ.get(
+        "PF_CORE_REF",
+        REPO_ROOT.parent / "provability-fabric-core",
+    )
+)
+NORMALIZE_PATH = (
+    PF_CORE_ROOT / "adapters" / "provability-fabric" / "mcp_sidecar" / "normalize.py"
+)
+FIXTURES = REPO_ROOT / "runtime" / "sidecar-watcher" / "tests" / "fixtures"
+SIDECAR_DIR = REPO_ROOT / "runtime" / "sidecar-watcher"
+
+PARITY_KEYS = (
+    "schema_version",
+    "trace_id",
+    "event_id",
+    "observation_id",
+    "decision",
+    "policy_ref",
+    "evidence_ref",
+    "runtime_ref",
+    "timestamp",
+    "previous_event_hash",
+)
+
+
+def _load_normalize():
+    if not NORMALIZE_PATH.is_file():
+        pytest.skip(f"reference normalize.py not found at {NORMALIZE_PATH}")
+    spec = importlib.util.spec_from_file_location("pf_sidecar_normalize", NORMALIZE_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(PF_CORE_ROOT / "pf-core" / "validator"))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _native_observation(fixture_name: str) -> Dict[str, Any]:
+    fixture = FIXTURES / fixture_name
+    proc = subprocess.run(
+        ["cargo", "run", "--quiet", "--bin", "emit_observation"],
+        cwd=SIDECAR_DIR,
+        input=fixture.read_text(encoding="utf-8"),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return json.loads(proc.stdout)
+
+
+def _parity_subset(obs: Mapping[str, Any]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {k: obs[k] for k in PARITY_KEYS if k in obs}
+    principal = obs.get("principal", {})
+    out["principal_id"] = principal.get("id")
+    out["tenant_id"] = principal.get("tenant_id")
+    out["roles"] = list(principal.get("roles", []))
+    action = obs.get("action", {})
+    cap = action.get("capability", {})
+    out["capability_id"] = cap.get("id")
+    effects = action.get("effects", [])
+    out["effect_kind"] = effects[0].get("kind") if effects else None
+    reads = action.get("reads", [])
+    out["resource_uri"] = reads[0].get("uri") if reads else None
+    return out
+
+
+@pytest.fixture(scope="module")
+def normalize_mod():
+    return _load_normalize()
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    ["sidecar_audit_line.json", "sidecar_denied_audit_line.json"],
+)
+def test_native_emitter_matches_normalize(fixture_name: str, normalize_mod) -> None:
+    line = json.loads((FIXTURES / fixture_name).read_text(encoding="utf-8"))
+    expected = normalize_mod.normalize_sidecar_line(line)
+    native = _native_observation(fixture_name)
+    assert _parity_subset(native) == _parity_subset(expected)
+
+
+def test_ambiguous_line_errors_in_both_paths(normalize_mod) -> None:
+    line = json.loads(
+        (FIXTURES / "sidecar_ambiguous_audit_line.json").read_text(encoding="utf-8")
+    )
+    with pytest.raises(ValueError, match="capability_hint"):
+        normalize_mod.normalize_sidecar_line(line)
+    proc = subprocess.run(
+        ["cargo", "run", "--quiet", "--bin", "emit_observation"],
+        cwd=SIDECAR_DIR,
+        input=json.dumps(line),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    assert "capability_hint" in (proc.stderr or proc.stdout)
+
+
+def test_compile_observation_on_native_allowed(normalize_mod) -> None:
+    pf_validator = PF_CORE_ROOT / "pf-core" / "validator"
+    schemas = PF_CORE_ROOT / "pf-core" / "schemas"
+    if not pf_validator.is_dir():
+        pytest.skip("provability-fabric-core pf-core validator not present")
+    native = _native_observation("sidecar_audit_line.json")
+    env = {**os.environ, "PYTHONPATH": str(pf_validator)}
+    obs_path = FIXTURES / "_native_allowed_obs.json"
+    obs_path.write_text(json.dumps(native, indent=2), encoding="utf-8")
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pf_core.cli",
+                "core",
+                "compile-observation",
+                "--schemas",
+                str(schemas),
+                "--file",
+                str(obs_path),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stderr or proc.stdout
+    finally:
+        obs_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- Add `emit_observation` CLI to emit `pf-core.runtime_observation.v1` from sidecar/admission audit JSON
- Document field mapping in `runtime/sidecar-watcher/docs/PF_CORE_AUDIT_MAPPING.md`
- Parity tests compare native Rust output to reference `normalize.py` on golden fixtures
- CI runs `scripts/test_admission_parity.sh` in PF-Core schema-check workflow

## Test plan

- [ ] `bash scripts/test_admission_parity.sh`
- [ ] Golden allowed/denied fixtures match normalize.py semantics
- [ ] Ambiguous `capability_hint` fails in both paths
- [ ] `compile-observation` accepts native allowed observation