### PR TITLE
fix(ci): Wave 7 post-merge wasm-scan, retrieval-gateway, docs

### DIFF
--- a/.github/workflows/wasm-scan.yaml
+++ b/.github/workflows/wasm-scan.yaml
@@ -31,9 +31,11 @@ jobs:
 
       - name: Install wasm-objdump
         run: |
-          # Install wasm-objdump from wabt
-          curl -L https://github.com/WebAssembly/wabt/releases/download/1.0.33/wabt-1.0.33-linux.tar.gz | tar xz
-          sudo cp wabt-1.0.33/bin/wasm-objdump /usr/local/bin/
+          # Install wasm-objdump from wabt (1.0.33 tarball removed upstream)
+          curl -fsSL -o wabt.tar.gz \
+            https://github.com/WebAssembly/wabt/releases/download/1.0.41/wabt-1.0.41-linux-x64.tar.gz
+          tar xzf wabt.tar.gz
+          sudo cp wabt-1.0.41/bin/wasm-objdump /usr/local/bin/
 
       - name: Build WASM sandbox
         run: |

--- a/docs/internal/ci-inventory-latest.md
+++ b/docs/internal/ci-inventory-latest.md
@@ -1,164 +1,157 @@
-﻿# CI workflow inventory (auto-generated)
+﻿CI workflow inventory - repo=SentinelOps-CI/provability-fabric branch=main
+WORKFLOW                                   TRIGGERS                     STATUS       URL
+--------------------------------------------------------------------------------------------------------------
+actionlint.yml                             push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706332
+adapters-ci.yml                            push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705475
+allowlist-sync.yaml                        push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706271
+art-benchmark.yaml                         push, pull_request, schedule failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399502401
+bench-nightly-criterion.yaml               push, pull_request, schedule, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585900934
+bench-swebench-smoke.yaml                  push, pull_request, schedule, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705704
+bench-swebench-stress-scheduled.yaml       schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28314414940
+bench-swebench-unit.yaml                   push, pull_request           failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576576
+billing-test.yaml                          push, pull_request, schedule failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399598636
+bundle-check.yaml                          pull_request                 no_run       -
+cargo-deny.yml                             push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705316
+cert-validate.yml                          push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705523
+chaos-nightly.yaml                         schedule, workflow_dispatch  success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568878282
+ci.yml                                     push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705582
+ci-nightly-pytest.yml                      schedule, workflow_dispatch  success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28576040030
+ci-weekly-full.yml                         schedule, workflow_dispatch  success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28367886347
+cla-bot.yaml                               pull_request, workflow_dispatch failure      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27528984318
+codeql.yaml                                push, pull_request, schedule queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705418
+compliance.yaml                            release, workflow_dispatch   no_run       -
+demo-e2e.yml                               push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705589
+dependency-review.yml                      pull_request                 no_run       -
+dep-graph.yaml                             pull_request                 no_run       -
+dfa.yaml                                   push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647153
+docs-build.yaml                            push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705338
+docs-deploy.yaml                           push                         queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705536
+dr-cross.yaml                              schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28313345565
+edge-load.yaml                             schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417787429
+egress.yml                                 push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705538
+evidence.yaml                              push, schedule, workflow_dispatch success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28569079948
+evidence-v01-smoke.yml                     push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705539
+fuzz.yaml                                  push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705323
+heartbeat-test.yaml                        pull_request, workflow_dispatch no_run       -
+incident-e2e.yaml                          workflow_dispatch            no_run       -
+incident-test.yaml                         push, pull_request, schedule failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399492108
+integration.yaml                           push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706085
+jwks-validate.yml                          push, workflow_dispatch      queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705444
+lean-morph.yml                             push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705506
+lean-offline.yaml                          push, schedule, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705320
+lean-style.yaml                            push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706852
+loadtest.yaml                              pull_request, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399924626
+marketplace-e2e.yaml                       push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705631
+morph-replay.yml                           push, workflow_dispatch      queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705516
+multiarch-build.yaml                       push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705304
+nightly-replay.yml                         schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568693881
+opa-test.yaml                              push, pull_request           failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/16584478677
+operational-excellence.yaml                push, pull_request, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399591865
+paper-conformance.yaml                     push, schedule, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705694
+pcs-ci.yml                                 push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705524
+perf.yaml                                  schedule, workflow_dispatch  cancelled*   https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28569153198
+performance-gate.yaml                      push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705629
+perf-proofmeter.yaml                       push, pull_request, schedule failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417776889
+pf-ci.yaml                                 workflow_call                failure      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677070943
+pf-cross-repo-consumer.yaml                pull_request, schedule       failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399838783
+pf-reusable-caller.yaml                    pull_request, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28572843688
+platform-cert-validate.yml                 push, pull_request, schedule, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705691
+platform-perf-smoke.yml                    push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706202
+platform-replay.yml                        push, pull_request, schedule, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705297
+policy-build.yml                           push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647162
+policy-gates.yaml                          push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585707156
+policy-pr-proof.yml                        pull_request                 no_run       -
+pr-comments.yml                            pull_request                 no_run       -
+privacy-test.yaml                          push, pull_request, schedule queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705511
+proof-bot.yaml                             schedule, workflow_dispatch, issue_comment success*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399500362
+proof-fuzz.yaml                            push, pull_request, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399477882
+proto-compat.yaml                          push, pull_request, schedule queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706169
+publish-updates.yaml                       push, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399543888
+rbac-test.yaml                             pull_request, workflow_dispatch no_run       -
+redteam.yaml                               pull_request, schedule, workflow_dispatch failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28312328896
+release.yaml                               push, workflow_dispatch      no_run*      -
+release-sbom.yml                           release                      no_run       -
+replay.yml                                 push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705517
+retrieval-gateway.yml                      push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706166
+reusable-ci-extended.yml                   workflow_call                no_run       -
+reusable-ci-go-node.yml                    workflow_call                no_run       -
+reusable-ci-lean.yml                       workflow_call                no_run       -
+reusable-ci-prepare.yml                    workflow_call                no_run       -
+reusable-ci-rust.yml                       workflow_call                no_run       -
+revocation-sync.yaml                       schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19400248470
+sbom-diff.yaml                             push, pull_request, release  queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705575
+scorecards.yml                             push, schedule, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706992
+slo-gates.yaml                             push, pull_request, schedule skipped*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647128
+spec-ai.yaml                               pull_request                 no_run       -
+standards-pin.yml                          push, pull_request, workflow_dispatch queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705309
+trust-fire-ga-test.yaml                    schedule, workflow_dispatch  failure*     https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28314313517
+verify-publish-bundle.yaml                 push, pull_request, workflow_dispatch no_run*      -
+wasm-scan.yaml                             push, pull_request           queued*      https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705335
 
-Generated: 2026-07-02T09:01:59Z UTC
-Repository: `SentinelOps-CI/provability-fabric` branch `main`
+Summary: total=86 gated(push/schedule)=68 green=5 red=63 unknown=18
+Markdown report written to C:\Users\mateo\provability-fabric\docs\internal\ci-inventory-latest.md
 
-## Summary
-
-| Metric | Count |
-|--------|------:|
-| Total workflow files | 86 |
-| Gated (push/schedule on main) | 68 |
-| Green (last run success) | 13 |
-| Red (failure/cancelled/in progress) | 53 |
-| No run / unknown | 20 |
-
-## Workflows
-
-| Workflow | Triggers | Last status | Gated | URL |
-|----------|----------|-------------|-------|-----|
-| `actionlint.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27676760872 |
-| `adapters-ci.yml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576589 |
-| `allowlist-sync.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576585 |
-| `art-benchmark.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399502401 |
-| `bench-nightly-criterion.yaml` | push, pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28569060330 |
-| `bench-swebench-smoke.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28577678541 |
-| `bench-swebench-stress-scheduled.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28314414940 |
-| `bench-swebench-unit.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576576 |
-| `billing-test.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399598636 |
-| `bundle-check.yaml` | pull_request | no_run | no | - |
-| `cargo-deny.yml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576613 |
-| `cert-validate.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27670516758 |
-| `chaos-nightly.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568878282 |
-| `ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677074379 |
-| `ci-nightly-pytest.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28576040030 |
-| `ci-weekly-full.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28367886347 |
-| `cla-bot.yaml` | pull_request, workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27528984318 |
-| `codeql.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28429083030 |
-| `compliance.yaml` | release, workflow_dispatch | no_run | no | - |
-| `demo-e2e.yml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27597109278 |
-| `dependency-review.yml` | pull_request | no_run | no | - |
-| `dep-graph.yaml` | pull_request | no_run | no | - |
-| `dfa.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576566 |
-| `docs-build.yaml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677074296 |
-| `docs-deploy.yaml` | push | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677074241 |
-| `dr-cross.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28313345565 |
-| `edge-load.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417787429 |
-| `egress.yml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27512638971 |
-| `evidence.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28569079948 |
-| `evidence-v01-smoke.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27686356513 |
-| `fuzz.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27509871701 |
-| `heartbeat-test.yaml` | pull_request, workflow_dispatch | no_run | no | - |
-| `incident-e2e.yaml` | workflow_dispatch | no_run | no | - |
-| `incident-test.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399492108 |
-| `integration.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27676760223 |
-| `jwks-validate.yml` | push, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/17535475445 |
-| `lean-morph.yml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27597316373 |
-| `lean-offline.yaml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576601 |
-| `lean-style.yaml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576592 |
-| `loadtest.yaml` | pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399924626 |
-| `marketplace-e2e.yaml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/17508000336 |
-| `morph-replay.yml` | push, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27597316360 |
-| `multiarch-build.yaml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677074328 |
-| `nightly-replay.yml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568693881 |
-| `opa-test.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/16584478677 |
-| `operational-excellence.yaml` | push, pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399591865 |
-| `paper-conformance.yaml` | push, pull_request, schedule | **in_progress** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568545852 |
-| `pcs-ci.yml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576571 |
-| `perf.yaml` | schedule, workflow_dispatch | **cancelled** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28569153198 |
-| `performance-gate.yaml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27676760071 |
-| `perf-proofmeter.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417776889 |
-| `pf-ci.yaml` | workflow_call | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677070943 |
-| `pf-cross-repo-consumer.yaml` | pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399838783 |
-| `pf-reusable-caller.yaml` | pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28572843688 |
-| `platform-cert-validate.yml` | push, pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568431511 |
-| `platform-perf-smoke.yml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27597172922 |
-| `platform-replay.yml` | push, pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28570861483 |
-| `policy-build.yml` | push, pull_request | **no_run** | yes | - |
-| `policy-gates.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576560 |
-| `policy-pr-proof.yml` | pull_request | no_run | no | - |
-| `pr-comments.yml` | pull_request | no_run | no | - |
-| `privacy-test.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28313655953 |
-| `proof-bot.yaml` | schedule, workflow_dispatch, issue_comment | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399500362 |
-| `proof-fuzz.yaml` | push, pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399477882 |
-| `proto-compat.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568320371 |
-| `publish-updates.yaml` | push, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399543888 |
-| `rbac-test.yaml` | pull_request, workflow_dispatch | no_run | no | - |
-| `redteam.yaml` | pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28312328896 |
-| `release.yaml` | push, workflow_dispatch | **no_run** | yes | - |
-| `release-sbom.yml` | release | no_run | no | - |
-| `replay.yml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27510612216 |
-| `retrieval-gateway.yml` | push, pull_request | **no_run** | yes | - |
-| `reusable-ci-extended.yml` | workflow_call | no_run | no | - |
-| `reusable-ci-go-node.yml` | workflow_call | no_run | no | - |
-| `reusable-ci-lean.yml` | workflow_call | no_run | no | - |
-| `reusable-ci-prepare.yml` | workflow_call | no_run | no | - |
-| `reusable-ci-rust.yml` | workflow_call | no_run | no | - |
-| `revocation-sync.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19400248470 |
-| `sbom-diff.yaml` | push, pull_request, release | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677074405 |
-| `scorecards.yml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28361288280 |
-| `slo-gates.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28568369544 |
-| `spec-ai.yaml` | pull_request | no_run | no | - |
-| `standards-pin.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27670516732 |
-| `trust-fire-ga-test.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28314313517 |
-| `verify-publish-bundle.yaml` | push, pull_request, workflow_dispatch | **no_run** | yes | - |
-| `wasm-scan.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/17750206124 |
-
-## Gated workflows not green
-
-- `adapters-ci.yml (failure)`
-- `allowlist-sync.yaml (failure)`
-- `art-benchmark.yaml (failure)`
-- `bench-nightly-criterion.yaml (failure)`
-- `bench-swebench-stress-scheduled.yaml (failure)`
-- `bench-swebench-unit.yaml (failure)`
-- `billing-test.yaml (failure)`
-- `cargo-deny.yml (failure)`
-- `codeql.yaml (failure)`
-- `demo-e2e.yml (failure)`
-- `dfa.yaml (failure)`
-- `docs-build.yaml (failure)`
-- `docs-deploy.yaml (failure)`
-- `dr-cross.yaml (failure)`
-- `edge-load.yaml (failure)`
-- `egress.yml (failure)`
-- `fuzz.yaml (failure)`
-- `incident-test.yaml (failure)`
-- `integration.yaml (failure)`
-- `jwks-validate.yml (failure)`
-- `lean-morph.yml (failure)`
-- `lean-offline.yaml (failure)`
-- `lean-style.yaml (failure)`
-- `loadtest.yaml (failure)`
-- `marketplace-e2e.yaml (failure)`
-- `morph-replay.yml (failure)`
-- `multiarch-build.yaml (failure)`
-- `nightly-replay.yml (failure)`
-- `opa-test.yaml (failure)`
-- `operational-excellence.yaml (failure)`
-- `paper-conformance.yaml (in_progress)`
-- `pcs-ci.yml (failure)`
-- `perf.yaml (cancelled)`
-- `performance-gate.yaml (failure)`
-- `perf-proofmeter.yaml (failure)`
-- `pf-cross-repo-consumer.yaml (failure)`
-- `pf-reusable-caller.yaml (failure)`
-- `platform-cert-validate.yml (failure)`
-- `platform-perf-smoke.yml (failure)`
-- `platform-replay.yml (failure)`
-- `policy-build.yml (no_run)`
-- `policy-gates.yaml (failure)`
-- `privacy-test.yaml (failure)`
-- `proof-fuzz.yaml (failure)`
-- `publish-updates.yaml (failure)`
-- `redteam.yaml (failure)`
-- `release.yaml (no_run)`
-- `replay.yml (failure)`
-- `retrieval-gateway.yml (no_run)`
-- `revocation-sync.yaml (failure)`
-- `sbom-diff.yaml (failure)`
-- `slo-gates.yaml (failure)`
-- `trust-fire-ga-test.yaml (failure)`
-- `verify-publish-bundle.yaml (no_run)`
-- `wasm-scan.yaml (failure)`
-
+Gated workflows not green on last main run:
+  - actionlint.yml (queued)
+  - adapters-ci.yml (queued)
+  - allowlist-sync.yaml (queued)
+  - art-benchmark.yaml (failure)
+  - bench-nightly-criterion.yaml (queued)
+  - bench-swebench-smoke.yaml (queued)
+  - bench-swebench-stress-scheduled.yaml (failure)
+  - bench-swebench-unit.yaml (failure)
+  - billing-test.yaml (failure)
+  - cargo-deny.yml (queued)
+  - cert-validate.yml (queued)
+  - ci.yml (queued)
+  - codeql.yaml (queued)
+  - demo-e2e.yml (queued)
+  - dfa.yaml (queued)
+  - docs-build.yaml (queued)
+  - docs-deploy.yaml (queued)
+  - dr-cross.yaml (failure)
+  - edge-load.yaml (failure)
+  - egress.yml (queued)
+  - evidence-v01-smoke.yml (queued)
+  - fuzz.yaml (queued)
+  - incident-test.yaml (failure)
+  - integration.yaml (queued)
+  - jwks-validate.yml (queued)
+  - lean-morph.yml (queued)
+  - lean-offline.yaml (queued)
+  - lean-style.yaml (queued)
+  - loadtest.yaml (failure)
+  - marketplace-e2e.yaml (queued)
+  - morph-replay.yml (queued)
+  - multiarch-build.yaml (queued)
+  - nightly-replay.yml (failure)
+  - opa-test.yaml (failure)
+  - operational-excellence.yaml (failure)
+  - paper-conformance.yaml (queued)
+  - pcs-ci.yml (queued)
+  - perf.yaml (cancelled)
+  - performance-gate.yaml (queued)
+  - perf-proofmeter.yaml (failure)
+  - pf-cross-repo-consumer.yaml (failure)
+  - pf-reusable-caller.yaml (failure)
+  - platform-cert-validate.yml (queued)
+  - platform-perf-smoke.yml (queued)
+  - platform-replay.yml (queued)
+  - policy-build.yml (queued)
+  - policy-gates.yaml (queued)
+  - privacy-test.yaml (queued)
+  - proof-fuzz.yaml (failure)
+  - proto-compat.yaml (queued)
+  - publish-updates.yaml (failure)
+  - redteam.yaml (failure)
+  - release.yaml (no_run)
+  - replay.yml (queued)
+  - retrieval-gateway.yml (queued)
+  - revocation-sync.yaml (failure)
+  - sbom-diff.yaml (queued)
+  - scorecards.yml (queued)
+  - slo-gates.yaml (skipped)
+  - standards-pin.yml (queued)
+  - trust-fire-ga-test.yaml (failure)
+  - verify-publish-bundle.yaml (no_run)
+  - wasm-scan.yaml (queued)

--- a/docs/internal/full-repo-audit-reassessment-2026-07-03.md
+++ b/docs/internal/full-repo-audit-reassessment-2026-07-03.md
@@ -8,9 +8,9 @@ Post-remediation reassessment of findings **F01–F39** after local audit progra
 
 | Scope | Detail |
 |-------|--------|
-| **Code state** | Remediation on branch `audit-remediation-merge` — **not merged to `main`** until PR #144 CI green. |
-| **CI on `main`** | **13 / 68** gated workflows green (inventory 2026-07-03); unchanged until merge. |
-| **PR #144 CI** | Head `518735c6`; latest CI [28583017161](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28583017161) queued. Prior push: branch checks **smoke** [84746594873](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582133952/job/84746594873), **evidence-schema-only** [84744736821](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582133952/job/84744736821), **Documentation Build** [84744733843](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134001/job/84744733843), **deny** [84744734402](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134163/job/84744734402) green; **CI required checks** awaiting green on `518735c6`. **Review:** `REVIEW_REQUIRED`. |
+| **Code state** | **Merged to `main`** at `95bcd563` (PR #136 + #144, 2026-07-03). |
+| **CI on `main`** | Post-merge inventory **5 / 68** gated workflows green (2026-07-03); **43 push workflows queued** on first merge wave (runs `28585705xxx`). Pre-merge baseline was 13/68. |
+| **Main CI** | [28585705582](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705582) queued on `95bcd563`. |
 | **Local gates** | All merge-gate commands below passed on working tree (2026-07-03). |
 | **68/68 sign-off** | **Not claimed.** Requires two consecutive `ci_workflow_inventory.sh` exit 0 on `main`. |
 
@@ -23,7 +23,7 @@ Post-remediation reassessment of findings **F01–F39** after local audit progra
 | Findings DONE | 32 | **36** |
 | Findings PARTIAL | 6 | **3** (F23, F24, F33 root Policy + MicroInterp) |
 | Findings OPEN | 1 (F38) | **0** |
-| Gated workflows green on `main` | 13 / 68 | **13 / 68** (pending merge) |
+| Gated workflows green on `main` | 13 / 68 | **5 / 68** post-merge snapshot (43 queued); refresh after wave completes |
 | Sidecar production unwrap/expect | 40 | **0** (`--max 10`) |
 | Ledger `any` | 76 | **0** (`--max 20`) |
 | CI honesty unjustified | 59 | **0** (56 justified) |
@@ -48,7 +48,7 @@ Post-remediation reassessment of findings **F01–F39** after local audit progra
 | `make docs-strict` | **0** | mkdocs strict |
 | `tests/replay/test_docker_invocation.sh` | skip/win | Docker required; wired in CI |
 | `bash scripts/linux_validation_checklist.sh` | partial/win | All non-Docker steps pass on Windows |
-| `scripts/ci_workflow_inventory.ps1 -Markdown` | **1** | 13/68 green on `main` |
+| `scripts/ci_workflow_inventory.ps1 -Markdown` | **1** | 5/68 green on `main` post-merge (`95bcd563`); 43 workflows queued |
 
 ---
 
@@ -80,19 +80,32 @@ F38 ESLint 9 migration complete (root flat config + packages).
 
 | ID | Hardening | Wired in CI | Main proof |
 |----|-----------|-------------|------------|
-| F01 | `PF_ENFORCE_DSSE=1` | `reusable-ci-extended.yml` → `test_cross_lang_dsse.py` | Pending merge; local pass |
-| F02 | Deny-by-default `PF_ENABLED_TOOLS=` | `env_config::enabled_tools_deny_by_default` in `sidecar-watcher --lib` tests (`reusable-ci-rust.yml`) + compose `PF_ENABLED_TOOLS=` | Pending merge |
-| F03/F04 | MCP tenant | `integration.yaml` → `test_ledger_mcp_tenant.py` | Pending merge; submodule init fixed |
-| F05 | retrieval-gateway | `retrieval-gateway.yml` | PR pass [28576347539](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28576347539); no `main` run yet |
-| F21 | Compose smoke | `integration.yaml` → `docker-compose-smoke.sh` | Pending merge Linux CI |
+| F01 | `PF_ENFORCE_DSSE=1` | `reusable-ci-extended.yml` → `test_cross_lang_dsse.py` | Main run pending [28585705582](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705582) queued |
+| F02 | Deny-by-default `PF_ENABLED_TOOLS=` | `env_config::enabled_tools_deny_by_default` in `sidecar-watcher --lib` tests (`reusable-ci-rust.yml`) + compose `PF_ENABLED_TOOLS=` | Main CI queued |
+| F03/F04 | MCP tenant | `integration.yaml` → `test_ledger_mcp_tenant.py` | [28585706085](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706085) queued |
+| F05 | retrieval-gateway | `retrieval-gateway.yml` | [28585706166](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706166) queued |
+| F21 | Compose smoke | `integration.yaml` → `docker-compose-smoke.sh` | [28585706085](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706085) queued |
 
 ---
 
-## Wave 7 execution log (2026-07-03, session 2)
+## Wave 7 execution log (2026-07-03, session 3 — post-merge)
 
 | Todo | Status | Evidence |
 |------|--------|----------|
-| phase0-merge-pr144 | **BLOCKED** | PR #144 open; head `518735c6`; 4/5 branch-protection checks green on prior push; `CI required checks` + GitHub review pending; merge **not executed** |
+| phase0-merge-pr144 | **DONE** | Merged `95bcd563` (PR #136 + #144) to `main` |
+| phase1-replay-security | **IN PROGRESS** | 43 post-merge runs queued (`28585705xxx`); cluster helper all `no_run`/pending |
+| phase1-platform-lean | **IN PROGRESS** | `integration.yaml` [28585706085](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706085), `paper-conformance.yaml` [28585705694](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705694) queued |
+| phase1-bench-docs | **IN PROGRESS** | `docs-build.yaml` [28585705338](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705338) queued; Criterion [28585900934](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585900934) queued |
+| phase1-remaining-workflows | **IN PROGRESS** | Inventory **5/68** honest snapshot; refresh after queue drains |
+| phase2-f33-policy | **PARTIAL** | `proofs/Policy.lean` 0 sorry; root `Policy.lean` 4 sorry; `MicroInterp.lean` 2 sorry |
+| phase3-hardening-proof | **IN PROGRESS** | F01/F03-F05/F21 runs queued on `95bcd563`; no conclusions yet |
+| phase4-signoff | **IN PROGRESS** | Docs + inventory refreshed; 68/68 **not claimed** |
+
+### Wave 7 execution log (2026-07-03, session 2 — superseded)
+
+| Todo | Status | Evidence |
+|------|--------|----------|
+| phase0-merge-pr144 | **DONE** | Superseded by session 3 merge |
 | phase1-replay-security | **NOT STARTED (main)** | PR-only green: `replay-tests`, `deny` [28582134163](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134163); post-merge cluster proof blocked on merge |
 | phase1-platform-lean | **NOT STARTED (main)** | `Invariants.lean` ENFORCED; `integration` compose smoke fix `05d9cd6a`; re-run [28583016953](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28583016953) queued |
 | phase1-bench-docs | **NOT STARTED (main)** | `Documentation Build` PR green [28582134001](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134001); Criterion baseline refresh not dispatched on `main` |
@@ -120,7 +133,7 @@ Runbook: [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md). Cluster hel
 
 ## Honest bottom line
 
-**Code remediation is complete for merge.** Wave 7 Phase 0 is **blocked** on PR #144: **`CI required checks`** must go green on head `518735c6`, **`integration`** compose smoke must pass with tool-broker Docker fix (`05d9cd6a`), and a **GitHub approving review** is required (`REVIEW_REQUIRED`). Four branch-protection checks (`smoke`, `evidence-schema-only`, `Documentation Build`, `deny`) already passed on the prior push. The program bottleneck remains **landing on `main` and proving CI clusters green twice** — not re-doing F16/F27/F38. Do not publish 68/68 or full evidence-program sign-off until inventory ceremony passes on `main`.
+**Code remediation merged to `main` (`95bcd563`).** Wave 7 Phase 1 is **in progress**: post-merge inventory reports **5/68** green with **43 workflows queued** on the first push wave. Cluster proof (replay, security, platform, lean, bench) awaits run conclusions — main CI [28585705582](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705582) still queued. **PR #143** (dependabot docs) rebased; CI [28586333806](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28586333806) pending — merge blocked until **CI required checks**, **smoke**, **evidence-schema-only**, **Documentation Build** green. **PR #138** remains **CONFLICTING** with `main`. Do not publish 68/68 or full evidence-program sign-off until inventory ceremony passes on `main` twice.
 
 ---
 

--- a/docs/internal/remediation-tracker.md
+++ b/docs/internal/remediation-tracker.md
@@ -10,23 +10,23 @@ Maps findings **F01–F39** from [full-repo-audit-2026-07-01.md](full-repo-audit
 
 ## CI baseline (Wave 0 inventory)
 
-Captured on Windows via `powershell -File scripts/ci_workflow_inventory.ps1 -ListOnly` (2026-07-01; requires `gh` CLI authenticated to repo).
+Captured via `powershell -File scripts/ci_workflow_inventory.ps1 -Markdown` (2026-07-03 post-merge; requires `gh` CLI authenticated to repo). Full table: [ci-inventory-latest.md](ci-inventory-latest.md).
 
 | Metric | Count |
 |--------|------:|
-| Total workflow files | 85 |
+| Total workflow files | 86 |
 | Gated (push/schedule on `main`) | 68 |
-| Latest run **success** | 13 |
-| Latest run **failure / in_progress / cancelled** | 53 |
-| No run / unknown | 19 |
+| Latest run **success** | 5 |
+| Latest run **failure / in_progress / cancelled** | 63 |
+| No run / unknown (queued) | 18 |
 
-**Green (13):** `actionlint.yml`, `bench-swebench-smoke.yaml`, `cert-validate.yml`, `chaos-nightly.yaml`, `ci.yml`, `ci-nightly-pytest.yml`, `ci-weekly-full.yml`, `evidence.yaml`, `evidence-v01-smoke.yml`, `proof-bot.yaml`, `proto-compat.yaml`, `scorecards.yml`, `standards-pin.yml`.
+**Green (5, post-merge snapshot):** `chaos-nightly.yaml`, `ci-nightly-pytest.yml`, `ci-weekly-full.yml`, `evidence.yaml`, `proof-bot.yaml` — prior scheduled runs; **43 push workflows queued** on merge commit `95bcd563` (runs `28585705xxx`).
 
-**No run on main (gated):** `policy-build.yml`, `release.yaml`, `verify-publish-bundle.yaml`.
+**No run on main (gated):** `policy-build.yml`, `release.yaml`, `verify-publish-bundle.yaml` (first post-merge run queued for policy-build).
 
 Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -File scripts/ci_workflow_inventory.ps1` (Windows).
 
-**Note:** Local remediation is **not yet merged to `main`**; inventory on `main` remains 13/68 until merge + Linux CI validation. **PR #144** head `518735c6` — CI gate fixes landed 2026-07-03; merge blocked on **`CI required checks`** + GitHub review. Merge PR prep: [merge-readiness-checklist.md](merge-readiness-checklist.md), [merge-pr-body.md](merge-pr-body.md).
+**Note:** **PR #136 + #144 merged** to `main` at `95bcd563` (2026-07-03). Post-merge inventory is **5/68** until the first push wave completes; pre-merge baseline was **13/68**. Main CI run [28585705582](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705582) queued on `95bcd563`. Wave 7 cluster triage: [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md).
 
 ---
 
@@ -114,7 +114,7 @@ Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -
 | 4 | Ledger + MCP consolidation | F03–F04, F09, F11, F22, F26–F28 | Docker MCP + Jest suite | **DONE** |
 | 5 | Architecture, demos, topology | F05, F07–F08, F18, F21, F29, F32, F34 | Demos/examples pass | **DONE** |
 | 6 | Quality, docs, formal methods | F33, F37–F39 | mkdocs strict; Lean enforced targets | **MOSTLY DONE** — F33 partial (Invariants **0** sorry + enforced; `proofs/Policy.lean` **0** sorry; root Policy + MicroInterp **6** remain); F38 done |
-| 7 | CI green program | All CI clusters | 67/67 gated green twice on main | **IN PROGRESS** — Phase 0/1 local prep complete; merge + two consecutive green runs still required |
+| 7 | CI green program | All CI clusters | 67/67 gated green twice on main | **IN PROGRESS** — merged `95bcd563`; post-merge inventory **5/68** (43 workflows queued); cluster proof pending first main completions |
 
 ---
 
@@ -132,7 +132,7 @@ Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -
 | Paper-conformance shadow mode | **DONE** (wired) | `paper-conformance.yaml` integration job sets `PF_SHADOW_MODE=1` |
 | Criterion `refresh_baseline` | **DOCUMENTED** | `bench/BASELINE.md` + `bench-nightly-criterion.yaml` `workflow_dispatch` input |
 
-**Still pending merge / main CI:** replay cluster green twice, platform/security clusters, 67/67 inventory. See [merge-readiness-checklist.md](merge-readiness-checklist.md).
+**Still pending main CI proof:** replay cluster green twice, platform/security clusters, 67/68 inventory. Merge landed `95bcd563`; see [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md).
 
 ---
 

--- a/docs/internal/wave7-post-merge-runbook.md
+++ b/docs/internal/wave7-post-merge-runbook.md
@@ -8,21 +8,19 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 
 ---
 
-## Status (2026-07-03 — Wave 7 execution, session 2)
+## Status (2026-07-03 — Wave 7 post-merge, session 3)
 
-**PR #144 not merged.** Head `518735c6` on `audit-remediation-merge`. Branch protection requires **CI required checks**, **smoke**, **evidence-schema-only**, **Documentation Build**, plus **1 approving review** (`reviewDecision: REVIEW_REQUIRED`).
+**Merged:** PR #136 + #144 at `95bcd563` on `main` (2026-07-03).
 
 | Phase | Status | Evidence |
 |-------|--------|----------|
-| 0 — Merge gate | **BLOCKED (CI + review)** | [PR #144](https://github.com/SentinelOps-CI/provability-fabric/pull/144); latest CI [28583017161](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28583017161) (queued on `518735c6`) |
-| 0 — Branch checks (partial green) | **4/5 required pass on prior push** | `smoke` [28582133952](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582133952) job [84746594873](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582133952/job/84746594873); `evidence-schema-only` [84744736821](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582133952/job/84744736821); `Documentation Build` [28582134001](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134001/job/84744733843); `deny` [28582134163](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134163/job/84744734402); **`CI required checks` pending** on [28582134426](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134426) (`ci-honesty` fail pre-fix [84744735085](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134426/job/84744735085); fixed in `518735c6`) |
-| 0 — CI fixes landed (2026-07-03) | **Committed** | `520205ac` Cargo.lock tracked; `3a935289` ledger lock; `3e3a934b`/`e7a1ae13` pf go.sum + typescript lock; `05d9cd6a` tool-broker/wasm-sandbox minimal workspace Dockerfiles; `518735c6` ci-honesty inline justifications |
-| 1.1 Replay cluster | **Pending merge** | `replay-tests` green on PR runs (e.g. [28582133952](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582133952)) |
-| 1.2 Security cluster | **Pending merge** | `deny` green [28582134163](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134163); CodeQL JS still red on PR |
-| 1.3 Platform cluster | **Pending merge** | `integration` red [28582134135](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134135) (compose smoke tool-broker; fix in `05d9cd6a`, re-run [28583016953](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28583016953) queued) |
-| 1.4 Lean + paper | **Preemptive** | `Invariants.lean` ENFORCED in `lean-style.yaml`; Lean Style Check green on PR |
-| 1.5 Bench + docs | **Partial PR green** | `Documentation Build` [28582134001](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134001/job/84744733843); Criterion smoke still running |
-| 1.6 Remaining ~30 | **Not started** | `main` still 13/68 green |
+| 0 — Merge gate | **DONE** | `95bcd563` on `main` |
+| 1.1 Replay cluster | **IN PROGRESS** | Post-merge runs queued (`28585705297` platform-replay, `28585705517` replay, `28585705516` morph-replay, `28585705691` platform-cert); cluster helper: all pending |
+| 1.2 Security cluster | **IN PROGRESS** | `codeql.yaml` [28585705418](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705418), `cargo-deny.yml` [28585705316](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705316), `scorecards.yml` [28585706992](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706992) queued |
+| 1.3 Platform cluster | **IN PROGRESS** | `integration.yaml` [28585706085](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706085), `demo-e2e.yml` [28585705589](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705589) queued |
+| 1.4 Lean + paper | **IN PROGRESS** | `lean-style.yaml` [28585706852](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706852), `paper-conformance.yaml` [28585705694](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705694) queued |
+| 1.5 Bench + docs | **IN PROGRESS** | `docs-build.yaml` [28585705338](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705338) queued |
+| 1.6 Remaining ~30 | **IN PROGRESS** | Inventory **5/68** (honest post-merge snapshot); 43 workflows queued |
 
 ### Post-merge commands (run immediately after PR #144 lands)
 

--- a/docs/roadmap/evidence-program-closure.md
+++ b/docs/roadmap/evidence-program-closure.md
@@ -22,7 +22,7 @@ scripts/ci_workflow_inventory.sh --markdown   # docs/internal/ci-inventory-lates
 # Windows: scripts/ci_workflow_inventory.ps1 -Markdown
 ```
 
-**Current posture (2026-07-03, Wave 7 session 2):** Local audit remediation program complete for code gates. Evidence lane remains **green** on `main`. Repo-wide CI is **not** fully green — inventory reports **13/68** gated workflows green. **PR #144 not merged** — head `518735c6`; CI fixes landed (`Cargo.lock`, ledger/typescript locks, pf `go.sum`, tool-broker Docker workspace, ci-honesty justifications); branch checks **smoke**/**evidence-schema-only**/**Documentation Build**/**deny** green on prior push; **`CI required checks`** + approving review pending. See [merge-readiness-checklist.md](../internal/merge-readiness-checklist.md), [wave7-post-merge-runbook.md](../internal/wave7-post-merge-runbook.md), and [full-repo-audit-reassessment-2026-07-03.md](../internal/full-repo-audit-reassessment-2026-07-03.md).
+**Current posture (2026-07-03, Wave 7 session 3 — post-merge):** PR #136 + #144 **merged** to `main` at `95bcd563`. Post-merge inventory: **5/68** gated workflows green (43 push workflows queued on first wave; runs `28585705xxx`). Main CI [28585705582](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705582) queued. Evidence lane (`evidence.yaml`) remains green. **PR #143** (dependabot pymdown-extensions) rebased onto `main`; CI pending. **68/68 not claimed.** See [wave7-post-merge-runbook.md](../internal/wave7-post-merge-runbook.md) and [full-repo-audit-reassessment-2026-07-03.md](../internal/full-repo-audit-reassessment-2026-07-03.md).
 
 **Do not claim 68/68** until `scripts/ci_workflow_inventory.sh` exits 0 twice consecutively on `main`.
 
@@ -95,9 +95,7 @@ Setup steps: [CONTRIBUTING.md](https://github.com/SentinelOps-CI/provability-fab
 | Post-#134 (`f55a98bd`) | 67 | 12 | 52 | 21 |
 | Audit snapshot (2026-07-02) | 67 | 13 | 53 | 19 |
 | Phase 0 refresh + F33/F24 (2026-07-02 local) | 67 | 13 | 53 | 19 |
-| Wave 7 execution (2026-07-03) | 68 | 13 | 55 | — |
-
-**PR #144:** not merged. CI snapshot run [28576347710](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28576347710). Key PR passes: `ci-honesty` [28576347710](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28576347710), `replay-tests` [28576347480](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28576347480), `retrieval-gateway` [28576347539](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28576347539), `Lean Style Check` [28576347346](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28576347346).
+| Wave 7 post-merge (2026-07-03, `95bcd563`) | 68 | 5 | 63 | 18 queued |
 
 ### Path to 67/67 (Wave 7)
 

--- a/proofs/Policy.lean
+++ b/proofs/Policy.lean
@@ -292,7 +292,7 @@ theorem read_requires_label_flow : ∀ (u : Principal) (doc : DocId) (path : Lis
         rcases hleft with h | h
         · exact hreader h
         · exact hadmin h
-      · rcases Bool.and_eq_true.mp hr with ⟨ho, heq⟩
+      · rcases (Bool.and_eq_true _ _).1 hr with ⟨ho, heq⟩
         exact howner ⟨ho, heq⟩)
   simp only [permitD]
   exact hdeny

--- a/runtime/retrieval-gateway/Dockerfile
+++ b/runtime/retrieval-gateway/Dockerfile
@@ -5,12 +5,17 @@
 
 FROM rust:1.88-bookworm AS builder
 WORKDIR /app
-
-COPY Cargo.toml Cargo.lock ./
-COPY runtime/retrieval-gateway/Cargo.toml runtime/retrieval-gateway/
-COPY core/crypto/dsse-rs/Cargo.toml core/crypto/dsse-rs/
-COPY core/crypto/dsse-rs/src core/crypto/dsse-rs/src
-COPY runtime/retrieval-gateway/src runtime/retrieval-gateway/src
+COPY core/crypto/dsse-rs ./core/crypto/dsse-rs
+COPY runtime/retrieval-gateway ./runtime/retrieval-gateway
+# Minimal workspace: root Cargo.toml lists members not copied into this context.
+RUN cat > Cargo.toml <<'EOF'
+[workspace]
+members = [
+    "core/crypto/dsse-rs",
+    "runtime/retrieval-gateway",
+]
+resolver = "2"
+EOF
 RUN cargo build --release -p retrieval-gateway
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
## Summary
- Bump wasm-scan wabt to 1.0.41 (upstream removed 1.0.33 tarball)
- Minimal Cargo workspace in retrieval-gateway Dockerfile
- proofs/Policy.lean Bool.and_eq_true API fix
- Refresh post-merge inventory (5/68) and tracker docs after merge 95bcd563

## Test plan
- [ ] CI required checks green
- [ ] smoke, evidence-schema-only, Documentation Build green
- [ ] wasm-scan and retrieval-gateway workflows pass on main after merge