### PR TITLE
fix(sdk): type trace verification in express middleware

### DIFF
--- a/core/sdk/typescript/src/middleware/express.ts
+++ b/core/sdk/typescript/src/middleware/express.ts
@@ -5,7 +5,7 @@
 type Request = any;
 type Response = any;
 type NextFunction = any;
-import { ProvabilityFabricSDK } from '../index';
+import { ProvabilityFabricSDK, type TraceVerificationResult } from '../index';
 
 export interface PFMiddlewareOptions {
   sdk: ProvabilityFabricSDK;
@@ -33,11 +33,11 @@ export function pfMiddleware(options: PFMiddlewareOptions) {
 
       // Verify trace if requested
       if (verifyTrace && req.body?.trace) {
-        const traceVerification = await Promise.race([
+        const traceVerification: TraceVerificationResult = await Promise.race([
           sdk.verifyTrace(req.body.trace),
-          new Promise((_, reject) => 
+          new Promise<never>((_, reject) =>
             setTimeout(() => reject(new Error('Trace verification timeout')), timeout)
-          )
+          ),
         ]);
 
         if (!traceVerification.valid) {


### PR DESCRIPTION
## Summary
- Type `Promise.race` result as `TraceVerificationResult` in express middleware
- Fixes TS18046 blocking integration Docker Compose smoke (verifiable-mcp-fraud SDK build)

## Test plan
- [ ] Integration Tests workflow green
- [ ] TypeScript SDK `npm run build` in CI