### PR TITLE
fix(docker): install musl target for multi-arch builds

### DIFF
--- a/runtime/attestor/Dockerfile
+++ b/runtime/attestor/Dockerfile
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
     musl-dev \
     openssl-dev \
     pkgconfig \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && rustup target add x86_64-unknown-linux-musl
 
 # Set working directory
 WORKDIR /app

--- a/runtime/egress-firewall/Dockerfile
+++ b/runtime/egress-firewall/Dockerfile
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
     musl-dev \
     openssl-dev \
     pkgconfig \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && rustup target add x86_64-unknown-linux-musl
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Add `rustup target add x86_64-unknown-linux-musl` to attestor and egress-firewall Alpine builder stages
- Fixes multiarch-build failure on main (`28631260395`): arm64 QEMU leg could not compile for musl because the Rust target was not installed

## Root cause
`cargo build --target x86_64-unknown-linux-musl` on the linux/arm64 buildx platform fails with `error[E0463]: can't find crate for core` unless the cross-compilation target is explicitly added.

## Test plan
- [ ] Multi-Architecture Build & Deploy passes on this PR
- [ ] attestor and egress-firewall images build for linux/amd64 and linux/arm64