### PR TITLE
fix(docker): native musl build for multi-arch images

### DIFF
--- a/runtime/attestor/Dockerfile
+++ b/runtime/attestor/Dockerfile
@@ -9,8 +9,7 @@ RUN apk add --no-cache \
     musl-dev \
     openssl-dev \
     pkgconfig \
-    && rm -rf /var/cache/apk/* \
-    && rustup target add x86_64-unknown-linux-musl
+    && rm -rf /var/cache/apk/*
 
 # Set working directory
 WORKDIR /app
@@ -22,13 +21,13 @@ COPY Cargo.toml ./
 RUN mkdir src && echo "fn main() {}" > src/main.rs
 
 # Build dependencies (this layer will be cached)
-RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN cargo build --release
 
 # Copy source code
 COPY src/ ./src/
 
 # Build the application
-RUN touch src/main.rs && cargo build --release --target x86_64-unknown-linux-musl
+RUN touch src/main.rs && cargo build --release
 
 # Runtime stage
 FROM alpine:3.19
@@ -47,7 +46,7 @@ RUN addgroup -g 1001 -S appgroup && \
 WORKDIR /app
 
 # Copy binary from builder stage
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/attestor ./
+COPY --from=builder /app/target/release/attestor ./
 
 # Set ownership
 RUN chown -R appuser:appgroup /app

--- a/runtime/egress-firewall/Dockerfile
+++ b/runtime/egress-firewall/Dockerfile
@@ -9,8 +9,7 @@ RUN apk add --no-cache \
     musl-dev \
     openssl-dev \
     pkgconfig \
-    && rm -rf /var/cache/apk/* \
-    && rustup target add x86_64-unknown-linux-musl
+    && rm -rf /var/cache/apk/*
 
 # Set working directory
 WORKDIR /app
@@ -22,13 +21,13 @@ COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && echo "fn main() {}" > src/main.rs
 
 # Build dependencies (this layer will be cached)
-RUN cargo build --release --target x86_64-unknown-linux-musl --no-default-features --features mimalloc
+RUN cargo build --release --no-default-features --features mimalloc
 
 # Copy source code
 COPY src/ ./src/
 
 # Build the application
-RUN cargo build --release --target x86_64-unknown-linux-musl --no-default-features --features mimalloc
+RUN cargo build --release --no-default-features --features mimalloc
 
 # Runtime stage
 FROM alpine:3.19
@@ -47,7 +46,7 @@ RUN addgroup -g 1001 -S appgroup && \
 WORKDIR /app
 
 # Copy binary from builder stage
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/egress-firewall ./
+COPY --from=builder /app/target/release/egress-firewall ./
 
 # Copy policy files
 COPY policies/ ./policies/


### PR DESCRIPTION
## Summary
- Stop cross-compiling to `x86_64-unknown-linux-musl` inside Alpine builder stages.
- Let buildx build native musl release binaries per platform (amd64/arm64).

## Test plan
- [ ] `multiarch-build.yaml` egress-firewall + attestor legs green on PR
- [ ] Two consecutive green `multiarch-build.yaml` runs on `main` after merge