### PR TITLE
fix(ci): grant packages:write for GHCR push on main

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -26,6 +26,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   # Multi-architecture build job
   build:


### PR DESCRIPTION
## Summary
- Add workflow-level `packages: write` permission so main-push image uploads to ghcr.io succeed
- PR builds already use load-only (no push); unchanged

## Test plan
- [ ] Multi-Architecture Build & Deploy green on main after merge