### PR TITLE
fix(ci): paper-conformance ancillary security-audit and benchmarks

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -26,6 +26,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   # Multi-architecture build job
   build:

--- a/.github/workflows/paper-conformance.yaml
+++ b/.github/workflows/paper-conformance.yaml
@@ -342,6 +342,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -383,15 +388,14 @@ jobs:
 
       - name: Run Security Audit
         run: |
-          cd runtime/sidecar-watcher
-          cargo audit
-          cargo geiger --output-format json > security_report.json
+          cargo audit -p sidecar-watcher
+          cargo geiger -p sidecar-watcher --output-format json > security_report.json
 
       - name: Upload Security Report
         uses: actions/upload-artifact@v4
         with:
           name: security-report
-          path: runtime/sidecar-watcher/security_report.json
+          path: security_report.json
 
   # Documentation Generation
   documentation:


### PR DESCRIPTION
## Summary
- Run `cargo audit` and `cargo geiger` from the workspace root with `-p sidecar-watcher` so the root `Cargo.lock` is used (fixes Security Audit failure on run 29410389616).
- Install `protobuf-compiler` before `cargo bench --all` in the Performance Benchmarks job (fixes missing `protoc` for `provability-fabric-core-sdk-rust`).

## Test plan
- [ ] Merge and verify full green `paper-conformance.yaml` on `main`
- [ ] Dispatch second consecutive run for F24 2/2 proof