### PR TITLE
fix(ci): use absolute manifest path for cargo-geiger

### DIFF
--- a/.github/workflows/paper-conformance.yaml
+++ b/.github/workflows/paper-conformance.yaml
@@ -387,7 +387,7 @@ jobs:
           set -e
           # cargo-audit exit 2 = operational failure (e.g. missing Cargo.lock)
           if [ "$audit_status" -eq 2 ]; then exit 2; fi
-          cargo geiger --manifest-path runtime/sidecar-watcher/Cargo.toml --output-format Json > security_report.json
+          cargo geiger --manifest-path "${GITHUB_WORKSPACE}/runtime/sidecar-watcher/Cargo.toml" --output-format Json > security_report.json
 
       - name: Upload Security Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
cargo-geiger requires absolute --manifest-path on Actions runners.