### PR TITLE
fix(ci): ignore multiarch GHA cache export failures

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -36,6 +36,8 @@ jobs:
     name: Build Multi-Arch Images
     runs-on: ubuntu-latest
     strategy:
+      # Let other matrix images finish push even if one job fails (e.g. cache backend).
+      fail-fast: false
       matrix:
         include:
           - service: sidecar-watcher
@@ -105,7 +107,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: ${{ github.event_name == 'pull_request' && 'type=inline' || 'type=gha,mode=max' }}
+          # ignore-error: GHA cache export 400s must not fail the job after a successful
+          # GHCR push (build+push is the gate; cache is best-effort).
+          cache-to: ${{ github.event_name == 'pull_request' && 'type=inline' || 'type=gha,mode=max,ignore-error=true' }}
 
       - name: Image size report
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- Multiarch run [29444995658](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29444995658) built and pushed images to GHCR, then failed on GHA cache export (HTTP 400 / service unavailable HTML).
- Same pattern as prior red [29441338384](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441338384): build+push OK, cache backend flaky.
- Set `cache-to: type=gha,mode=max,ignore-error=true` so cache export is best-effort (not `continue-on-error` on the build step).
- Set matrix `fail-fast: false` so one matrix cell does not cancel sibling image pushes.

## Test plan
- [ ] PR `multiarch-build` job builds (amd64) without requiring GHA cache write
- [ ] After merge, dispatch `multiarch-build.yaml` on `main` and confirm conclusion=success when GHCR push succeeds
- [ ] Confirm images present on GHCR for sidecar-watcher / attestor / egress-firewall
