### PR TITLE
fix(ci): fix multiarch Trivy empty image tag

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -176,10 +176,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Resolve GHCR image ref
+        id: image
+        run: |
+          set -euo pipefail
+          # GHCR paths are lowercase; build job tags sha-<7> via docker/metadata-action.
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          repo="$(echo '${{ github.event.repository.name }}' | tr '[:upper:]' '[:lower:]')"
+          short="$(echo '${{ github.sha }}' | cut -c1-7)"
+          echo "ref=${{ env.REGISTRY }}/${owner}/${repo}/sidecar-watcher:sha-${short}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/sidecar-watcher:${{ needs.build.outputs.version }}
+          image-ref: ${{ steps.image.outputs.ref }}
           format: "sarif"
           output: "trivy-results.sarif"
 


### PR DESCRIPTION
## Summary
- After #178, all three multiarch build matrix jobs green on `main` ([29448418996](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29448418996)); workflow still red because Security Scan used `${{ needs.build.outputs.version }}` (empty).
- Resolve `ghcr.io/<owner>/<repo>/sidecar-watcher:sha-<7>` (lowercase) and login to GHCR before Trivy.

## Test plan
- [ ] After merge, `multiarch-build` Security Scan parses a valid image ref
- [ ] Full workflow conclusion=success on `main` when builds + scan succeed
