### PR TITLE
fix(ci): multiarch Security Scan security-events write

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -171,6 +171,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+      security-events: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Add job-scoped `security-events: write` (plus `contents`/`packages`/`actions` read) on multiarch Security Scan so Trivy SARIF upload can write to the GitHub Security tab.
- Unblocks tip failures after image-ref fix where Trivy succeeded but upload returned Resource not accessible by integration.

## Test plan
- [ ] PR gets green CI required checks
- [ ] After merge, main multiarch Security Scan uploads SARIF successfully