### PR TITLE
fix(ci): point ops cargo-audit at workspace Cargo.lock

### DIFF
--- a/.github/workflows/operational-excellence.yaml
+++ b/.github/workflows/operational-excellence.yaml
@@ -445,12 +445,11 @@ jobs:
           gosec -fmt json -out gosec-results.json ./... || test -f gosec-results.json
 
       - name: Run Rust security scanner
-        working-directory: runtime/sidecar-watcher
         run: |
-          # cargo-audit has no --manifest-path; run from the crate directory.
+          # Workspace lockfile lives at repo root (sidecar-watcher has no local Cargo.lock).
           # Exit non-zero on advisories is OK if JSON output was produced.
-          cargo audit --json > ../../cargo-audit-results.json \
-            || test -s ../../cargo-audit-results.json
+          cargo audit --file Cargo.lock --json > cargo-audit-results.json \
+            || test -s cargo-audit-results.json
 
       - name: Upload security scan results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- `operational-excellence` `performance-benchmarks` is green on main tip `8d2cd809`.
- `security-scanning` still failed because `cargo audit` ran without the workspace `Cargo.lock`.
- Audit from repo root with `--file Cargo.lock` (no continue-on-error).

## Test plan
- [ ] `operational-excellence` security-scanning + final-validation green on this PR
- [ ] Confirm tip run after merge
