### PR TITLE
fix(ci): repair egress low-view harness and CERT schema load

### DIFF
--- a/.github/workflows/egress.yml
+++ b/.github/workflows/egress.yml
@@ -7,12 +7,14 @@ on:
       - "scripts/check-egress.sh"
       - ".github/workflows/egress.yml"
       - "external/**"
+      - "tests/replay/**"
   pull_request:
     branches: [main, develop]
     paths:
       - "scripts/check-egress.sh"
       - ".github/workflows/egress.yml"
       - "external/**"
+      - "tests/replay/**"
   workflow_dispatch:
 
 jobs:
@@ -30,7 +32,10 @@ jobs:
       - name: Generate replay outputs for egress analysis
         run: |
           chmod +x tests/replay/run_replays.sh
-          export REPLAY_RUNS=1
+          # Pairwise low-view needs >=2 CERT runs per bundle
+          export REPLAY_RUNS=2
+          export CERT_V1_SCHEMA_REQUIRED=1
+          export CERT_V1_SCHEMA_PATH=/work/tests/replay/schema/trace-replay-cert.schema.json
           bash tests/replay/run_replays.sh
 
       - name: Run EGRESS-DET-P1 harness

--- a/core/cli/pf/platform_commands.go
+++ b/core/cli/pf/platform_commands.go
@@ -2037,9 +2037,9 @@ func traceCompareLowViewCmd() *cobra.Command {
 			}
 			// Oracle expects positional cert paths and --min-determinism as a percent
 			minDeterminism := threshold * 100.0
-			args := append([]string{oracle}, certs...)
-			args = append(args, "--min-determinism", fmt.Sprintf("%f", minDeterminism))
-			cmdExec := exec.Command(interp, args...)
+			pyArgs := append([]string{oracle}, certs...)
+			pyArgs = append(pyArgs, "--min-determinism", fmt.Sprintf("%f", minDeterminism))
+			cmdExec := exec.Command(interp, pyArgs...)
 			cmdExec.Stdout = os.Stdout
 			cmdExec.Stderr = os.Stderr
 			if err := cmdExec.Run(); err != nil {

--- a/core/cli/pf/platform_commands.go
+++ b/core/cli/pf/platform_commands.go
@@ -2024,24 +2024,52 @@ func traceCompareLowViewCmd() *cobra.Command {
 				interp = "python"
 			}
 			oracle := "external/TRACE-REPLAY-KIT/oracles/lowview_equal.py"
-			if _, err := os.Stat(oracle); err == nil {
-				args := []string{oracle, "--input", inputDir, "--threshold", fmt.Sprintf("%f", threshold)}
-				cmdExec := exec.Command(interp, args...)
-				cmdExec.Stdout = os.Stdout
-				cmdExec.Stderr = os.Stderr
-				if err := cmdExec.Run(); err != nil {
-					return fmt.Errorf("low-view compare failed: %w", err)
-				}
-				fmt.Println("✅ Low-view comparison passed")
+			if _, err := os.Stat(oracle); err != nil {
+				fmt.Println("ℹ️  Oracle not found; skipping")
 				return nil
 			}
-			fmt.Println("ℹ️  Oracle not found; skipping")
+			certs, err := collectReplayCerts(inputDir)
+			if err != nil {
+				return err
+			}
+			if len(certs) < 2 {
+				return fmt.Errorf("need >=2 CERT files under %s for low-view compare (found %d)", inputDir, len(certs))
+			}
+			// Oracle expects positional cert paths and --min-determinism as a percent
+			minDeterminism := threshold * 100.0
+			args := append([]string{oracle}, certs...)
+			args = append(args, "--min-determinism", fmt.Sprintf("%f", minDeterminism))
+			cmdExec := exec.Command(interp, args...)
+			cmdExec.Stdout = os.Stdout
+			cmdExec.Stderr = os.Stderr
+			if err := cmdExec.Run(); err != nil {
+				return fmt.Errorf("low-view compare failed: %w", err)
+			}
+			fmt.Println("✅ Low-view comparison passed")
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&inputDir, "in", "", "Input directory of replay outputs")
 	cmd.Flags().Float64Var(&threshold, "threshold", 0.999999, "Low-view equality threshold")
 	return cmd
+}
+
+// collectReplayCerts finds *.cert.json under dir or dir/certs.
+func collectReplayCerts(dir string) ([]string, error) {
+	candidates := []string{
+		filepath.Join(dir, "*.cert.json"),
+		filepath.Join(dir, "certs", "*.cert.json"),
+	}
+	var out []string
+	for _, pattern := range candidates {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, matches...)
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 // computeJSONDiff renders a simple line-by-line diff of two JSON strings

--- a/scripts/check-egress.sh
+++ b/scripts/check-egress.sh
@@ -1,35 +1,82 @@
 #!/usr/bin/env bash
+# EGRESS-DET-P1: pairwise low-view determinism across replay CERT runs.
+# Uses TRACE-REPLAY-KIT oracles/lowview_equal.py (positional certs + --min-determinism).
 set -euo pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
 REPORT_DIR="$ROOT_DIR/evidence/egress"
+CERT_DIR="$ROOT_DIR/tests/replay/out/certs"
+KIT_ORACLE="$ROOT_DIR/external/TRACE-REPLAY-KIT/oracles/lowview_equal.py"
+# Fraction 0.999999 -> percent 99.9999 (oracle --min-determinism)
+MIN_DETERMINISM="${LOWVIEW_MIN_DETERMINISM:-99.9999}"
+PROFILE_TAG="EGRESS-DET-P1@1.0"
+
 mkdir -p "$REPORT_DIR"
 
-echo "# Egress Determinism Report" > "$REPORT_DIR/report.md"
-echo >> "$REPORT_DIR/report.md"
-echo "Generated: $(date -u)" >> "$REPORT_DIR/report.md"
-echo >> "$REPORT_DIR/report.md"
+{
+  echo "# Egress Determinism Report"
+  echo
+  echo "Generated: $(date -u)"
+  echo
+  echo "Profile: $PROFILE_TAG"
+  echo "- Cert dir: $CERT_DIR"
+  echo "- Oracle: $KIT_ORACLE"
+  echo "- min-determinism: $MIN_DETERMINISM"
+  echo
+} >"$REPORT_DIR/report.md"
 
-PROFILE_TAG="EGRESS-DET-P1@1.0"
-ENV_JSON="$ROOT_DIR/tests/replay/env.json"
-KIT_DIR="$ROOT_DIR/external/TRACE-REPLAY-KIT"
-
-echo "Running EGRESS harness for profile $PROFILE_TAG" >> "$REPORT_DIR/report.md"
-echo "- Env: $ENV_JSON" >> "$REPORT_DIR/report.md"
-
-set +e
-python3 "$KIT_DIR/oracles/lowview_equal.py" \
-  --input "$ROOT_DIR/tests/replay/out" \
-  --threshold 0.999999 >> "$REPORT_DIR/report.md" 2>&1
-RESULT=$?
-set -e
-
-if [ $RESULT -ne 0 ]; then
-  echo "- Result: FAIL (threshold not met or missing inputs)" >> "$REPORT_DIR/report.md"
+if [[ ! -f "$KIT_ORACLE" ]]; then
+  echo "- Result: FAIL (missing oracle at $KIT_ORACLE; run make submodules)" >>"$REPORT_DIR/report.md"
+  echo "Report written to $REPORT_DIR/report.md"
   exit 1
-else
-  echo "- Result: PASS (>= 0.999999 low-view equality)" >> "$REPORT_DIR/report.md"
 fi
 
-echo "Report written to $REPORT_DIR/report.md"
+if [[ ! -d "$CERT_DIR" ]]; then
+  echo "- Result: FAIL (missing cert dir $CERT_DIR; run tests/replay/run_replays.sh first)" >>"$REPORT_DIR/report.md"
+  echo "Report written to $REPORT_DIR/report.md"
+  exit 1
+fi
 
+shopt -s nullglob
+FAIL=0
+COMPARED=0
+
+for bundle_dir in "$ROOT_DIR/tests/replay/bundles"/*; do
+  [[ -d "$bundle_dir" ]] || continue
+  name=$(basename "$bundle_dir")
+  certs=("$CERT_DIR/${name}_run"*.cert.json)
+
+  if [[ ${#certs[@]} -lt 2 ]]; then
+    echo "- Bundle $name: FAIL (need >=2 certs for low-view compare, found ${#certs[@]})" >>"$REPORT_DIR/report.md"
+    FAIL=1
+    continue
+  fi
+
+  echo "- Bundle $name: comparing ${#certs[@]} cert(s)" >>"$REPORT_DIR/report.md"
+  set +e
+  python3 "$KIT_ORACLE" "${certs[@]}" --min-determinism "$MIN_DETERMINISM" >>"$REPORT_DIR/report.md" 2>&1
+  RESULT=$?
+  set -e
+  COMPARED=$((COMPARED + 1))
+
+  if [[ $RESULT -ne 0 ]]; then
+    echo "- Bundle $name: FAIL (low-view threshold not met)" >>"$REPORT_DIR/report.md"
+    FAIL=1
+  else
+    echo "- Bundle $name: PASS (>= $MIN_DETERMINISM low-view equality)" >>"$REPORT_DIR/report.md"
+  fi
+done
+
+if [[ $COMPARED -eq 0 && $FAIL -eq 0 ]]; then
+  echo "- Result: FAIL (no replay bundles found under tests/replay/bundles)" >>"$REPORT_DIR/report.md"
+  FAIL=1
+fi
+
+if [[ $FAIL -ne 0 ]]; then
+  echo "- Result: FAIL" >>"$REPORT_DIR/report.md"
+  echo "Report written to $REPORT_DIR/report.md"
+  exit 1
+fi
+
+echo "- Result: PASS" >>"$REPORT_DIR/report.md"
+echo "Report written to $REPORT_DIR/report.md"

--- a/tests/replay/overlays/replay_run.py
+++ b/tests/replay/overlays/replay_run.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+TRACE-REPLAY-KIT Replay Runner (PF overlay)
+
+Identical to external/TRACE-REPLAY-KIT/runner/replay_run.py except schema
+loading prefers CERT_V1_SCHEMA_PATH / the in-repo fixture. The upstream
+raw.githubusercontent.com CERT-V1 URL 404s (private repo + wrong filename).
+"""
+
+import argparse
+import json
+import os
+import sys
+import hashlib
+from datetime import datetime
+import jsonschema
+import requests
+from typing import Dict, Any, List
+
+
+# Upstream URL (kept as last-resort fallback; currently 404 for private CERT-V1)
+CERT_V1_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/verifiable-ai-ci/"
+    "CERT-V1/v1.0.0/schema/cert-v1.json"
+)
+
+LOCAL_SCHEMA_CANDIDATES = [
+    "/work/tests/replay/schema/trace-replay-cert.schema.json",
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "tests",
+        "replay",
+        "schema",
+        "trace-replay-cert.schema.json",
+    ),
+]
+
+
+class ReplayRunner:
+    """Main replay runner class."""
+
+    def __init__(self):
+        self.cert_schema = None
+        self.load_cert_schema()
+
+    def load_cert_schema(self):
+        """Load schema: env/local fixture first, then pinned URL."""
+        candidates: List[str] = []
+        env_path = os.environ.get("CERT_V1_SCHEMA_PATH")
+        if env_path:
+            candidates.append(env_path)
+        candidates.extend(LOCAL_SCHEMA_CANDIDATES)
+
+        for path in candidates:
+            if not path:
+                continue
+            try:
+                if os.path.isfile(path):
+                    with open(path, "r", encoding="utf-8") as f:
+                        self.cert_schema = json.load(f)
+                    print(f"Loaded CERT schema from: {path}")
+                    return
+            except Exception as e:
+                print(f"Warning: Could not load CERT schema from {path}: {e}")
+
+        try:
+            response = requests.get(CERT_V1_SCHEMA_URL, timeout=30)
+            response.raise_for_status()
+            self.cert_schema = response.json()
+            print(f"Loaded CERT schema from URL: {CERT_V1_SCHEMA_URL}")
+            return
+        except Exception as e:
+            print(f"Warning: Could not load CERT-V1 schema: {e}")
+            self.cert_schema = None
+
+        if os.environ.get("CERT_V1_SCHEMA_REQUIRED") == "1":
+            raise RuntimeError(
+                "CERT schema required (CERT_V1_SCHEMA_REQUIRED=1) but none loaded"
+            )
+
+    def validate_trace(self, trace_path: str) -> Dict[str, Any]:
+        """Validate and load trace file."""
+        try:
+            with open(trace_path, "r") as f:
+                trace_data = json.load(f)
+
+            if "events" not in trace_data:
+                raise ValueError("Trace must contain 'events' array")
+
+            if "metadata" not in trace_data:
+                raise ValueError("Trace must contain 'metadata'")
+
+            return trace_data
+        except Exception as e:
+            raise ValueError(f"Invalid trace file: {e}")
+
+    def validate_env(self, env_path: str) -> Dict[str, Any]:
+        """Validate and load environment configuration."""
+        try:
+            with open(env_path, "r") as f:
+                env_data = json.load(f)
+
+            required_fields = ["locale", "timezone", "seed", "versions"]
+            for field in required_fields:
+                if field not in env_data:
+                    raise ValueError(f"Environment must contain '{field}'")
+
+            return env_data
+        except Exception as e:
+            raise ValueError(f"Invalid environment file: {e}")
+
+    def execute_replay(
+        self, trace_data: Dict[str, Any], env_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Execute the replay based on trace and environment."""
+        os.environ["LC_ALL"] = env_data["locale"]
+        os.environ["TZ"] = env_data["timezone"]
+        os.environ["PYTHONHASHSEED"] = str(env_data["seed"])
+
+        results = []
+        for event in trace_data["events"]:
+            result = self.process_event(event, env_data)
+            results.append(result)
+
+        return {
+            "replay_id": hashlib.sha256(
+                json.dumps(trace_data, sort_keys=True).encode()
+            ).hexdigest()[:16],
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "environment": env_data,
+            "results": results,
+            "summary": {
+                "total_events": len(results),
+                "successful_events": len(
+                    [r for r in results if r["status"] == "success"]
+                ),
+                "failed_events": len([r for r in results if r["status"] == "failed"]),
+            },
+        }
+
+    def process_event(
+        self, event: Dict[str, Any], env_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Process a single event from the trace."""
+        try:
+            event_type = event.get("type", "unknown")
+
+            if event_type == "function_call":
+                return self.process_function_call(event, env_data)
+            elif event_type == "streaming_egress":
+                return self.process_streaming_egress(event, env_data)
+            elif event_type == "declassification":
+                return self.process_declassification(event, env_data)
+            elif event_type == "epoch_revocation":
+                return self.process_epoch_revocation(event, env_data)
+            else:
+                return {
+                    "event_id": event.get("id", "unknown"),
+                    "status": "skipped",
+                    "message": f"Unknown event type: {event_type}",
+                }
+        except Exception as e:
+            return {
+                "event_id": event.get("id", "unknown"),
+                "status": "failed",
+                "error": str(e),
+            }
+
+    def process_function_call(
+        self, event: Dict[str, Any], env_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Process a function call event."""
+        return {
+            "event_id": event.get("id"),
+            "status": "success",
+            "type": "function_call",
+            "result": f"Executed {event.get('payload', {}).get('function', 'unknown')}",
+        }
+
+    def process_streaming_egress(
+        self, event: Dict[str, Any], env_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Process a streaming egress event."""
+        return {
+            "event_id": event.get("id"),
+            "status": "success",
+            "type": "streaming_egress",
+            "result": "Stream processed successfully",
+        }
+
+    def process_declassification(
+        self, event: Dict[str, Any], env_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Process a declassification event."""
+        return {
+            "event_id": event.get("id"),
+            "status": "success",
+            "type": "declassification",
+            "result": "Security level changed",
+        }
+
+    def process_epoch_revocation(
+        self, event: Dict[str, Any], env_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Process an epoch revocation event."""
+        return {
+            "event_id": event.get("id"),
+            "status": "success",
+            "type": "epoch_revocation",
+            "result": "Epoch access revoked",
+        }
+
+    def generate_cert_v1(
+        self, replay_result: Dict[str, Any], trace_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Generate a CERT-V1 certificate."""
+        schema_ref = os.environ.get(
+            "CERT_V1_SCHEMA_PATH",
+            "https://provability-fabric.local/schemas/trace-replay-cert.schema.json",
+        )
+        cert = {
+            "$schema": schema_ref,
+            "cert_type": "trace_replay",
+            "version": "1.0.0",
+            "timestamp": replay_result["timestamp"],
+            "replay_id": replay_result["replay_id"],
+            "trace_metadata": trace_data.get("metadata", {}),
+            "environment": replay_result["environment"],
+            "results": replay_result["results"],
+            "summary": replay_result["summary"],
+            "signature": {
+                "algorithm": "sha256",
+                "hash": hashlib.sha256(
+                    json.dumps(replay_result, sort_keys=True).encode()
+                ).hexdigest(),
+            },
+        }
+
+        if self.cert_schema:
+            try:
+                jsonschema.validate(cert, self.cert_schema)
+            except jsonschema.ValidationError as e:
+                print(
+                    f"Warning: Generated certificate does not validate against schema: {e}"
+                )
+                if os.environ.get("CERT_V1_SCHEMA_REQUIRED") == "1":
+                    raise
+
+        return cert
+
+    def run(self, args):
+        """Main execution method."""
+        try:
+            trace_data = self.validate_trace(args.trace)
+            env_data = self.validate_env(args.fixtures + "/env.json")
+
+            replay_result = self.execute_replay(trace_data, env_data)
+
+            cert = self.generate_cert_v1(replay_result, trace_data)
+
+            if args.cert_out:
+                with open(args.cert_out, "w") as f:
+                    json.dump(cert, f, indent=2)
+                print(f"Certificate written to: {args.cert_out}")
+            else:
+                print(json.dumps(cert, indent=2))
+
+            if replay_result["summary"]["failed_events"] > 0:
+                sys.exit(1)
+
+        except Exception as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="TRACE-REPLAY-KIT Replay Runner")
+    parser.add_argument("--bundle", help="Path to bundle directory")
+    parser.add_argument("--trace", required=True, help="Path to trace.json file")
+    parser.add_argument("--fixtures", required=True, help="Path to fixtures directory")
+    parser.add_argument("--cert-out", help="Output path for CERT-V1 certificate")
+    parser.add_argument(
+        "--validate-env", help="Validate environment configuration file"
+    )
+
+    args = parser.parse_args()
+
+    runner = ReplayRunner()
+
+    if args.validate_env:
+        try:
+            env_data = runner.validate_env(args.validate_env)
+            print("Environment configuration is valid")
+            print(json.dumps(env_data, indent=2))
+        except Exception as e:
+            print(f"Environment validation failed: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        runner.run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/replay/run_replays.sh
+++ b/tests/replay/run_replays.sh
@@ -9,10 +9,19 @@ KIT_DIR="$ROOT_DIR/external/TRACE-REPLAY-KIT/runner"
 OUT_DIR="$ROOT_DIR/tests/replay/out"
 CERT_DIR="$OUT_DIR/certs"
 ENV_JSON="$ROOT_DIR/tests/replay/env.json"
+OVERLAY_RUNNER="$ROOT_DIR/tests/replay/overlays/replay_run.py"
+# Local fixture: upstream CERT-V1 raw URL 404s (private + wrong filename)
+DEFAULT_SCHEMA="/work/tests/replay/schema/trace-replay-cert.schema.json"
+CERT_V1_SCHEMA_PATH="${CERT_V1_SCHEMA_PATH:-$DEFAULT_SCHEMA}"
 
 mkdir -p "$CERT_DIR"
 
 echo "Using TRACE-REPLAY-KIT at: $KIT_DIR"
+
+if [ ! -f "$OVERLAY_RUNNER" ]; then
+  echo "Error: missing runner overlay at $OVERLAY_RUNNER" >&2
+  exit 1
+fi
 
 # Build Docker image for reproducible runs
 IMAGE_TAG="trace-replay-runner:kit"
@@ -33,11 +42,15 @@ for b in "$ROOT_DIR/tests/replay/bundles"/*; do
   for i in $(seq 1 "$REPLAY_RUNS"); do
     cert_out_host="$CERT_DIR/${name}_run${i}.cert.json"
 
-    # Invoke runner inside container with mounted repo for deterministic env
-    # Image ENTRYPOINT is `python replay_run.py`; pass CLI args directly.
+    # Invoke runner inside container with mounted repo for deterministic env.
+    # ENTRYPOINT is `python replay_run.py` with -w set to the KIT runner dir, so the
+    # overlay must replace that path (not /app/replay_run.py alone).
     docker run --rm \
       -e TZ=UTC -e LC_ALL=C.UTF-8 \
+      -e CERT_V1_SCHEMA_PATH="$CERT_V1_SCHEMA_PATH" \
+      -e CERT_V1_SCHEMA_REQUIRED="${CERT_V1_SCHEMA_REQUIRED:-0}" \
       -v "$ROOT_DIR":/work \
+      -v "$OVERLAY_RUNNER":/work/external/TRACE-REPLAY-KIT/runner/replay_run.py:ro \
       -w /work/external/TRACE-REPLAY-KIT/runner \
       "$IMAGE_TAG" \
         --bundle "/work/tests/replay/bundles/$name" \

--- a/tests/replay/schema/trace-replay-cert.schema.json
+++ b/tests/replay/schema/trace-replay-cert.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://provability-fabric.local/schemas/trace-replay-cert.schema.json",
+  "title": "TRACE-REPLAY-KIT certificate",
+  "description": "Local fixture schema for KIT-emitted trace_replay certificates. The private CERT-V1 raw URL (cert-v1.json) is not fetchable in CI; sidecar cert-v1.schema.json describes a different shape.",
+  "type": "object",
+  "required": [
+    "cert_type",
+    "version",
+    "timestamp",
+    "replay_id",
+    "environment",
+    "results",
+    "summary",
+    "signature"
+  ],
+  "properties": {
+    "$schema": { "type": "string" },
+    "cert_type": { "const": "trace_replay" },
+    "version": { "type": "string" },
+    "timestamp": { "type": "string" },
+    "replay_id": { "type": "string" },
+    "trace_metadata": { "type": "object" },
+    "environment": {
+      "type": "object",
+      "required": ["locale", "timezone", "seed", "versions"],
+      "properties": {
+        "locale": { "type": "string" },
+        "timezone": { "type": "string" },
+        "seed": {},
+        "versions": { "type": "object" }
+      },
+      "additionalProperties": true
+    },
+    "results": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total_events", "successful_events", "failed_events"],
+      "properties": {
+        "total_events": { "type": "integer" },
+        "successful_events": { "type": "integer" },
+        "failed_events": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "signature": {
+      "type": "object",
+      "required": ["algorithm", "hash"],
+      "properties": {
+        "algorithm": { "type": "string" },
+        "hash": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
- Fix EGRESS-DET-P1: `check-egress.sh` now calls `lowview_equal.py` with positional CERT files and `--min-determinism` (the previous `--input`/`--threshold` flags are not supported).
- Set `REPLAY_RUNS=2` so pairwise low-view comparison has inputs; fail closed when fewer than two CERTs exist.
- Load a local KIT `trace_replay` CERT schema fixture via a runner overlay (upstream CERT-V1 raw URL 404s); require schema load in the egress workflow.

## Test plan
- [ ] Local: `REPLAY_RUNS=2 CERT_V1_SCHEMA_REQUIRED=1 bash tests/replay/run_replays.sh` then `bash scripts/check-egress.sh` (PASS)
- [ ] PR `egress.yml` job green (schema loaded from fixture, no fake continue-on-error)
- [ ] Post-merge tip run of Egress Determinism succeeds
