### PR TITLE
fix(ci): install PyYAML in bench-swebench-unit

### DIFF
--- a/.github/workflows/bench-swebench-unit.yaml
+++ b/.github/workflows/bench-swebench-unit.yaml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install pytest and PyYAML
-        run: python -m pip install --upgrade pip pytest pyyaml
+      - name: Install pytest and deps
+        run: python -m pip install --upgrade pip pytest pyyaml requests
 
       - name: Run bench/swebench and experiments unit tests
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/bench-swebench-unit.yaml
+++ b/.github/workflows/bench-swebench-unit.yaml
@@ -8,6 +8,7 @@ on:
       - "experiments/**"
       - "tests/test_*.py"
       - "tests/fixtures/**"
+      - ".github/workflows/bench-swebench-unit.yaml"
   pull_request:
     branches: [main]
     paths:
@@ -15,6 +16,8 @@ on:
       - "experiments/**"
       - "tests/test_*.py"
       - "tests/fixtures/**"
+      - ".github/workflows/bench-swebench-unit.yaml"
+  workflow_dispatch:
 
 jobs:
   pytest:
@@ -31,8 +34,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install pytest and PyYAML
+        run: python -m pip install --upgrade pip pytest pyyaml
 
       - name: Run bench/swebench and experiments unit tests
         if: matrix.os == 'ubuntu-latest'

--- a/tests/test_check_wsl_env.py
+++ b/tests/test_check_wsl_env.py
@@ -68,6 +68,11 @@ def _run_main(
         if sys.platform == "win32" and not fail_fcntl and not fail_resource and "fcntl" not in sys.modules:
             sys.modules["fcntl"] = types.ModuleType("fcntl")
             stubbed.append("fcntl")
+        if not fail_datasets_swebench:
+            for mod_name in ("datasets", "swebench"):
+                if mod_name not in fail_imports and mod_name not in sys.modules:
+                    sys.modules[mod_name] = types.ModuleType(mod_name)
+                    stubbed.append(mod_name)
 
         with mock.patch.dict(mod.os.environ, env_patch, clear=False):
             with mock.patch.object(mod.sys, "argv", av):

--- a/tests/test_validate_pf_run.py
+++ b/tests/test_validate_pf_run.py
@@ -35,9 +35,9 @@ def test_validate_pf_run_fails_when_compliance_missing():
     root = make_fake_runpair(instance_ids=["a"])
     try:
         pf_run_dir = root / "pf" / "fake-run-001"
-        inst_dir = next(pf_run_dir.iterdir()) if pf_run_dir.is_dir() else None
-        if inst_dir and inst_dir.is_dir():
-            (inst_dir / "policy_compliance_summary.json").unlink(missing_ok=True)
+        inst_dirs = sorted(d for d in pf_run_dir.iterdir() if d.is_dir())
+        assert inst_dirs, "expected at least one instance directory"
+        (inst_dirs[0] / "policy_compliance_summary.json").unlink(missing_ok=True)
         ok, messages = validate_run(pf_run_dir)
         assert ok is False
         assert any("policy_compliance_summary" in m or "compliance" in m.lower() for m in messages)


### PR DESCRIPTION
## Summary
- Install `pyyaml` alongside pytest in `bench-swebench-unit.yaml` (matches `bench-swebench-smoke.yaml`).
- Root cause of run 27596576576: policy pack loader and guarded-mode smoke tests require PyYAML; without it 8 tests failed on ubuntu/windows.
- Add `workflow_dispatch` and self-path trigger so workflow changes re-run on merge and inventory can refresh.

## Test plan
- [x] Local Windows CI subset: 86 passed, 1 skipped
- [ ] PR: Bench SWE-bench unit (ubuntu + windows)
- [ ] Post-merge: main tip green for bench-swebench-unit