### PR TITLE
fix(ci): drop proof-bot issue_comment trigger

### DIFF
--- a/.github/workflows/proof-bot.yaml
+++ b/.github/workflows/proof-bot.yaml
@@ -4,9 +4,6 @@ on:
   schedule:
     # Run nightly at 2 AM UTC
     - cron: "0 2 * * *"
-  issue_comment:
-    # Trigger on "/prove" comment
-    types: [created]
   workflow_dispatch:
     # Manual trigger
 
@@ -18,12 +15,7 @@ permissions:
 jobs:
   proof-bot:
     runs-on: ubuntu-latest
-
-    # Schedule/dispatch on main; issue_comment only for explicit /prove commands.
-    if: |
-      (github.event_name != 'issue_comment' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'issue_comment' &&
-       contains(github.event.comment.body, '/prove'))
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout repository
@@ -79,42 +71,3 @@ jobs:
             auto-proof
             enhancement
           assignees: ${{ github.repository_owner }}
-
-      - name: Comment on Issue
-        if: github.event_name == 'issue_comment' && steps.proofbot.outcome == 'success'
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.login === 'github-actions[bot]' &&
-              comment.body.includes('Auto-proof: Resolve admits via APOLLO')
-            );
-
-            if (!botComment) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: `APOLLO Proof Bot has processed the repository and created a pull request to resolve admits.`
-              });
-            }
-
-      - name: Comment on Issue (No Changes)
-        if: github.event_name == 'issue_comment' && steps.proofbot.outcome == 'failure'
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `APOLLO Proof Bot found no admits to resolve or encountered an error. Check the workflow logs for details.`
-            });


### PR DESCRIPTION
## Summary
- Skipped issue_comment runs were overwriting successful proof-bot dispatch status in inventory
- Remove issue_comment trigger; keep schedule + workflow_dispatch

## Test plan
- [ ] Dispatch proof-bot on main after merge; last status success
- [ ] Inventory shows proof-bot green
