### PR TITLE
docs(ci): close F23 Criterion; inventory 51/67

### DIFF
--- a/bench/BASELINE.md
+++ b/bench/BASELINE.md
@@ -1,12 +1,11 @@
 # Criterion Baseline (F23)
 
-Status: **workflow ready** — `workflow_dispatch` input `refresh_baseline` is wired in
-`.github/workflows/bench-nightly-criterion.yaml`. Measured baseline refresh is pending the
-first green `save-baseline` run on Linux CI.
+Status: **DONE** — baseline refreshed on Linux CI (`save-baseline` green ×3 on `main` @
+`1ab0d2d5`, including push + two `refresh_baseline=true` dispatches).
 
 The nightly `Bench Nightly Criterion` workflow compares against a Criterion baseline named `main`
-under `target/criterion/`. Until a baseline is saved from a green main run, scheduled compare jobs
-seed a baseline on first cache miss (see `compare-baseline` job).
+under `target/criterion/` (Actions cache key `criterion-main-*`). Scheduled compare jobs seed a
+baseline on first cache miss (see `compare-baseline` job).
 
 CI passes Criterion CLI overrides (`--sample-size 50 --measurement-time 5 --noplot`) so jobs stay
 inside the Actions timeout budget; local `make bench-save-baseline` still uses the full group
@@ -23,18 +22,19 @@ with date (UTC), git SHA, and machine metadata.
 
 ## Refresh via CI
 
-1. Merge Wave 1 workflow fixes to `main`.
-2. In GitHub Actions, run **Bench Nightly Criterion** with `workflow_dispatch` and set
+1. In GitHub Actions, run **Bench Nightly Criterion** with `workflow_dispatch` and set
    `refresh_baseline: true` (boolean input). A push to `main` under `bench/**` also triggers
    the `save-baseline` job.
-3. Record the green run SHA and date below after the first successful refresh.
-4. Confirm the next scheduled compare job passes.
+2. Record the green run SHA and date below after a successful refresh.
+3. Confirm a subsequent scheduled (or non-refresh dispatch) compare job passes.
 
 | Field | Value |
 |-------|-------|
-| Last refresh SHA | _pending first CI run_ |
-| Last refresh date (UTC) | _pending_ |
+| Last refresh SHA | `1ab0d2d53ca09d97bc4bab2b013fef25b668d7c4` |
+| Last refresh date (UTC) | 2026-07-16T15:25:40Z |
+| Last refresh machine | Linux 6.17.0-1018-azure x86_64 (GitHub Actions ubuntu-latest) |
 | Workflow | `bench-nightly-criterion.yaml` (`refresh_baseline: true`) |
+| Proof runs | [29508973817](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973817) (push), [29509027731](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29509027731) (dispatch), [29509041247](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29509041247) (dispatch) |
 
 ## Thresholds
 

--- a/docs/internal/ci-inventory-latest.md
+++ b/docs/internal/ci-inventory-latest.md
@@ -1,6 +1,6 @@
-﻿# CI workflow inventory (auto-generated)
+# CI workflow inventory (auto-generated)
 
-Generated: 2026-07-15T19:33:11Z UTC
+Generated: 2026-07-16T15:40:41Z UTC
 Repository: `SentinelOps-CI/provability-fabric` branch `main`
 
 ## Summary
@@ -8,87 +8,87 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | Metric | Count |
 |--------|------:|
 | Total workflow files | 87 |
-| Gated (push/schedule on main) | 69 |
-| Green (last run success) | 39 |
-| Red (failure/cancelled/in progress) | 30 |
+| Gated (push/schedule on main) | 67 |
+| Green (last run success) | 51 |
+| Red (failure/cancelled/in progress) | 18 |
 | No run / unknown | 18 |
 
 ## Workflows
 
 | Workflow | Triggers | Last status | Gated | URL |
 |----------|----------|-------------|-------|-----|
-| `actionlint.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441338295 |
-| `adapters-ci.yml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922311 |
+| `actionlint.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29503093069 |
+| `adapters-ci.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29477314927 |
 | `allowlist-sync.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706271 |
-| `art-benchmark.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399502401 |
-| `bench-nightly-criterion.yaml` | push, pull_request, schedule, workflow_dispatch | **cancelled** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29400233715 |
-| `bench-swebench-smoke.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29399443152 |
+| `art-benchmark.yaml` | workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399502401 |
+| `bench-nightly-criterion.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29509041247 |
+| `bench-swebench-smoke.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29482360310 |
 | `bench-swebench-stress-scheduled.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29181697304 |
-| `bench-swebench-unit.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27596576576 |
-| `billing-test.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29390196605 |
+| `bench-swebench-unit.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29488165243 |
+| `billing-test.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29473465754 |
 | `bundle-check.yaml` | pull_request | no_run | no | - |
 | `cargo-deny.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28631247789 |
-| `cert-validate.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28625116959 |
-| `chaos-nightly.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29389944563 |
-| `ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441338622 |
-| `ci-nightly-pytest.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29397125062 |
+| `cert-validate.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279849 |
+| `chaos-nightly.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29473147086 |
+| `ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508974204 |
+| `ci-nightly-pytest.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29480168292 |
 | `ci-weekly-full.yml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29239884669 |
 | `cla-bot.yaml` | pull_request, workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27528984318 |
-| `codeql.yaml` | push, pull_request, schedule | **in_progress** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441338299 |
+| `codeql.yaml` | push, pull_request, schedule | **in_progress** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508974027 |
 | `compliance.yaml` | release, workflow_dispatch | no_run | no | - |
-| `demo-e2e.yml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705589 |
+| `demo-e2e.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404745 |
 | `dependency-review.yml` | pull_request | no_run | no | - |
 | `dep-graph.yaml` | pull_request | no_run | no | - |
 | `dfa.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647153 |
-| `docs-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29400238049 |
-| `docs-deploy.yaml` | push | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29400238330 |
+| `docs-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404720 |
+| `docs-deploy.yaml` | push | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404749 |
 | `dr-cross.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29180887456 |
 | `edge-load.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417787429 |
-| `egress.yml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705538 |
-| `evidence.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29390099186 |
-| `evidence-v01-smoke.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28630303030 |
-| `fuzz.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29400234167 |
+| `egress.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279890 |
+| `evidence.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29473345023 |
+| `evidence-v01-smoke.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404721 |
+| `fuzz.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973816 |
 | `heartbeat-test.yaml` | pull_request, workflow_dispatch | no_run | no | - |
 | `incident-e2e.yaml` | workflow_dispatch | no_run | no | - |
-| `incident-test.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29389873758 |
-| `integration.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29410389617 |
+| `incident-test.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29482489571 |
+| `integration.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973757 |
 | `jwks-validate.yml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705444 |
 | `lean-morph.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922346 |
-| `lean-offline.yaml` | push, schedule, workflow_dispatch | **cancelled** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29391379051 |
+| `lean-offline.yaml` | workflow_dispatch | cancelled | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29491617791 |
 | `lean-style.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28622922304 |
 | `loadtest.yaml` | pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399924626 |
 | `marketplace-e2e.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705631 |
-| `morph-replay.yml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705516 |
-| `multiarch-build.yaml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441338384 |
-| `nightly-replay.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29389783725 |
-| `opa-test.yaml` | push, pull_request | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/16584478677 |
-| `operational-excellence.yaml` | push, pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441338305 |
-| `paper-conformance.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29443718127 |
-| `pcs-ci.yml` | push, pull_request, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28630303009 |
-| `perf.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29390157047 |
-| `performance-gate.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705629 |
+| `morph-replay.yml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279955 |
+| `multiarch-build.yaml` | push, pull_request, workflow_dispatch | **in_progress** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973857 |
+| `nightly-replay.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29472546438 |
+| `opa-test.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29489277608 |
+| `operational-excellence.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973849 |
+| `paper-conformance.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973676 |
+| `pcs-ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29477314965 |
+| `perf.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29473421092 |
+| `performance-gate.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973836 |
 | `perf-proofmeter.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417776889 |
 | `pf-ci.yaml` | workflow_call | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677070943 |
-| `pf-core-schema-check.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441338364 |
+| `pf-core-schema-check.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973811 |
 | `pf-cross-repo-consumer.yaml` | pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399838783 |
-| `pf-reusable-caller.yaml` | pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29393328663 |
-| `platform-cert-validate.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29389451594 |
+| `pf-reusable-caller.yaml` | pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29475941844 |
+| `platform-cert-validate.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29472261494 |
 | `platform-perf-smoke.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28639549722 |
-| `platform-replay.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29391814477 |
+| `platform-replay.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29474618227 |
 | `policy-build.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647162 |
-| `policy-gates.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29400234277 |
+| `policy-gates.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973752 |
 | `policy-pr-proof.yml` | pull_request | no_run | no | - |
 | `pr-comments.yml` | pull_request | no_run | no | - |
-| `privacy-test.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29400234105 |
-| `proof-bot.yaml` | schedule, workflow_dispatch, issue_comment | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441339172 |
-| `proof-fuzz.yaml` | push, pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29389829657 |
-| `proto-compat.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29389325187 |
+| `privacy-test.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973818 |
+| `proof-bot.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29496609026 |
+| `proof-fuzz.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29483988820 |
+| `proto-compat.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29472131307 |
 | `publish-updates.yaml` | push, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399543888 |
 | `rbac-test.yaml` | pull_request, workflow_dispatch | no_run | no | - |
 | `redteam.yaml` | pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29179664746 |
 | `release.yaml` | push, workflow_dispatch | **no_run** | yes | - |
 | `release-sbom.yml` | release | no_run | no | - |
-| `replay.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705517 |
+| `replay.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279862 |
 | `retrieval-gateway.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29410389588 |
 | `reusable-ci-extended.yml` | workflow_call | no_run | no | - |
 | `reusable-ci-go-node.yml` | workflow_call | no_run | no | - |
@@ -96,41 +96,27 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | `reusable-ci-prepare.yml` | workflow_call | no_run | no | - |
 | `reusable-ci-rust.yml` | workflow_call | no_run | no | - |
 | `revocation-sync.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19400248470 |
-| `sbom-diff.yaml` | push, pull_request, release | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441338256 |
-| `scorecards.yml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441338415 |
-| `slo-gates.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29410389917 |
+| `sbom-diff.yaml` | push, pull_request, release | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973720 |
+| `scorecards.yml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973899 |
+| `slo-gates.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29472182424 |
 | `spec-ai.yaml` | pull_request | no_run | no | - |
-| `standards-pin.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28625116949 |
+| `standards-pin.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404740 |
 | `trust-fire-ga-test.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29181636975 |
 | `verify-publish-bundle.yaml` | push, pull_request, workflow_dispatch | **no_run** | yes | - |
 | `wasm-scan.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29410389729 |
 
 ## Gated workflows not green
 
-- `adapters-ci.yml (failure)`
-- `art-benchmark.yaml (failure)`
-- `bench-nightly-criterion.yaml (cancelled)`
 - `bench-swebench-stress-scheduled.yaml (failure)`
-- `bench-swebench-unit.yaml (failure)`
-- `billing-test.yaml (failure)`
 - `ci-weekly-full.yml (failure)`
 - `codeql.yaml (in_progress)`
-- `demo-e2e.yml (failure)`
 - `dr-cross.yaml (failure)`
 - `edge-load.yaml (failure)`
-- `egress.yml (failure)`
-- `incident-test.yaml (failure)`
-- `lean-offline.yaml (cancelled)`
 - `loadtest.yaml (failure)`
-- `multiarch-build.yaml (failure)`
-- `opa-test.yaml (failure)`
-- `operational-excellence.yaml (failure)`
-- `pcs-ci.yml (failure)`
+- `multiarch-build.yaml (in_progress)`
 - `perf.yaml (failure)`
 - `perf-proofmeter.yaml (failure)`
 - `pf-cross-repo-consumer.yaml (failure)`
-- `proof-bot.yaml (failure)`
-- `proof-fuzz.yaml (failure)`
 - `publish-updates.yaml (failure)`
 - `redteam.yaml (failure)`
 - `release.yaml (no_run)`

--- a/docs/internal/remediation-tracker.md
+++ b/docs/internal/remediation-tracker.md
@@ -83,7 +83,7 @@ Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -
 | F20 | P1 | CodeQL artifact upload broken | 1 | **DONE** | — | — | `codeql.yaml` matrix |
 | F21 | P1 | Runtime components absent from compose | 5 | **DONE** | — | — | `docker-compose.yml` profiles + `scripts/docker-compose-smoke.sh` |
 | F22 | P1 | `ws` missing from ledger | 4 | **DONE** | — | — | `package.json`; `mcp-websocket.test.cjs` smoke stub |
-| F23 | P1 | Bench Nightly Criterion regression | 1 | **PARTIAL** | — | — | `bench-nightly-criterion.yaml` `refresh_baseline` input; `bench/BASELINE.md`; needs main CI refresh |
+| F23 | P1 | Bench Nightly Criterion regression | 1 | **DONE** | — | [#197](https://github.com/SentinelOps-CI/provability-fabric/pull/197), [#198](https://github.com/SentinelOps-CI/provability-fabric/pull/198) | Green ×3 on `main` @ `1ab0d2d5`: [29508973817](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973817) (push), [29509027731](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29509027731) + [29509041247](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29509041247) (`refresh_baseline`); timeout CI overrides + ring-buffer MPMC hang fix |
 | F24 | P1 | Paper Conformance sidecar integration failures | 1, 3 | **DONE** | — | [#176](https://github.com/SentinelOps-CI/provability-fabric/pull/176) | `paper-conformance.yaml` green ×2 on `main` @ `f4b0859e`: [29441338434](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29441338434) (push), [29443718127](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29443718127) (dispatch); integration gates unchanged |
 | F25 | P1 | Egress cert evidence hardcoded accept | 2 | **DONE** | PH-005 | — | `env_config::resolve_evidence_hash`; `egress_evidence_enforcement.rs` |
 | F26 | P2 | Duplicate ledger entrypoints | 4 | **DONE** | — | — | `index-simple.ts` / `index-production.ts` removed; single `index.ts` + PROFILE env |
@@ -108,13 +108,13 @@ Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -
 | Wave | Focus | Findings | Exit gate | Status (2026-07-02) |
 |------|-------|----------|-----------|---------------------|
 | 0 | Foundation / truth baseline | F36 | Tracker + burn-down reconciled | **DONE** |
-| 1 | CI unblock and honesty | F06, F10–F12, F19–F24 | Replay green; ≥25/67 workflows green | **MOSTLY DONE** — F24 closed on `main` @ `f4b0859e` (paper-conformance ×2); F23 Criterion baseline refresh still pending |
+| 1 | CI unblock and honesty | F06, F10–F12, F19–F24 | Replay green; ≥25/67 workflows green | **DONE** — F24 closed @ `f4b0859e`; F23 Criterion green ×3 on `main` @ `1ab0d2d5` (#197/#198) |
 | 2 | Trust chain core | F01–F02, F17, F25 | Cross-lang DSSE; fail-closed when enforced | **DONE** |
 | 3 | Runtime hardening + sidecar CI | F13–F16, F30–F31, F35 | Sidecar in PR CI | **DONE** |
 | 4 | Ledger + MCP consolidation | F03–F04, F09, F11, F22, F26–F28 | Docker MCP + Jest suite | **DONE** |
 | 5 | Architecture, demos, topology | F05, F07–F08, F18, F21, F29, F32, F34 | Demos/examples pass | **DONE** |
 | 6 | Quality, docs, formal methods | F33, F37–F39 | mkdocs strict; Lean enforced targets | **MOSTLY DONE** — F33 partial (Invariants **0** sorry + enforced; `proofs/Policy.lean` **0** sorry; root Policy + MicroInterp **6** remain); F38 done |
-| 7 | CI green program | All CI clusters | 69/69 gated green twice on main | **IN PROGRESS** — `f4b0859e` on `main`; F24 DONE; next multiarch GHCR/cache retry (#164 merged, last run red on GHA cache export); F23 + demo-e2e / ops-excellence / billing still red |
+| 7 | CI green program | All CI clusters | 69/69 gated green twice on main | **IN PROGRESS** — `1ab0d2d5` on `main`; F23+F24 DONE; inventory **51/67**; next clear gated reds: `multiarch-build` / `perf.yaml` / DR-AWS cluster |
 
 ---
 
@@ -130,9 +130,9 @@ Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -
 | `passWithNoTests` removed | **DONE** | `marketplace-e2e.yaml` — conditional Jest or skip |
 | Sidecar `integration_tests` in PR Rust CI | **DONE** | `reusable-ci-rust.yml` with `PF_SHADOW_MODE=1` |
 | Paper-conformance shadow mode | **DONE** (wired) | `paper-conformance.yaml` integration job sets `PF_SHADOW_MODE=1` |
-| Criterion `refresh_baseline` | **DOCUMENTED** | `bench/BASELINE.md` + `bench-nightly-criterion.yaml` `workflow_dispatch` input |
+| Criterion `refresh_baseline` | **DONE** | Green ×3 @ `1ab0d2d5`; `bench/BASELINE.md` recorded; #197/#198 |
 
-**Still pending main CI proof:** multiarch (GHCR/Actions cache retry; #164 merged), bench baseline refresh (F23), confirmed-red triage (demo-e2e, operational-excellence DR/AWS, billing), 69/69 inventory ×2. Main @ `f4b0859e`; F24 DONE — see [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md).
+**Still pending main CI proof:** multiarch (GHCR/Actions cache), `perf.yaml` / DR-AWS / stress / weekly-full cluster, 67/67 inventory ×2. Main @ `1ab0d2d5`; F23+F24 DONE — see [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md).
 
 ---
 

--- a/docs/internal/wave7-post-merge-runbook.md
+++ b/docs/internal/wave7-post-merge-runbook.md
@@ -8,9 +8,21 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 
 ---
 
-## Status (2026-07-15 — Wave 7 post-merge, session 6)
+## Status (2026-07-16 — Wave 7 / F23 closeout)
 
-**Merged:** PR #136 + #144 at `95bcd563`; **PR #146** merged 2026-07-02; **PR #151** at `ee68659c`; **PR #163** (F24 scheduler); **PR #164** (multiarch musl); **PR #176** at `f4b0859e` (paper-conformance geiger drop / F24 closeout). **Main head:** `f4b0859e`.
+**Merged:** **PR #197** (Criterion CI timeouts/overrides); **PR #198** (ring-buffer MPMC hang). **Main head:** `1ab0d2d5`. Inventory **51/67**.
+
+| Phase | Status | Evidence |
+|-------|--------|----------|
+| 0 — Merge gate | **DONE** | `1ab0d2d5` on `main` |
+| 1.4 Lean + paper | **DONE (F24)** | `paper-conformance` green ×2 @ `f4b0859e` |
+| 1.5 Bench + docs | **DONE (F23)** | `bench-nightly-criterion` green ×3 @ `1ab0d2d5`: [29508973817](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973817), [29509027731](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29509027731), [29509041247](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29509041247) |
+| 1.6 Remaining | **IN PROGRESS** | Next clear gated red: `perf.yaml` (confirmed failure); `multiarch-build` tip run in progress |
+| **Next action** | **Triage `perf.yaml`** | Last fail [29473421092](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29473421092); watch multiarch [29508973857](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973857) |
+
+### Prior status (2026-07-15 — Wave 7 post-merge, session 6)
+
+**Merged:** PR #136 + #144 at `95bcd563`; **PR #146** merged 2026-07-02; **PR #151** at `ee68659c`; **PR #163** (F24 scheduler); **PR #164** (multiarch musl); **PR #176** at `f4b0859e` (paper-conformance geiger drop / F24 closeout). **Main head (then):** `f4b0859e`.
 
 | Phase | Status | Evidence |
 |-------|--------|----------|


### PR DESCRIPTION
## Summary
- Mark F23 **DONE** after Criterion green ×3 on `main` @ `1ab0d2d5` (#197/#198).
- Refresh `bench/BASELINE.md` + inventory (**51/67**).
- Next clear gated red: `perf.yaml` (`path` undefined TypeError on [29473421092](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29473421092)).

## Test plan
- [ ] Docs-only; no runtime change