### PR TITLE
fix(ci): replace broken gh-pages CLI in perf.yaml

### DIFF
--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -9,6 +9,9 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: write
+
 jobs:
   performance:
     runs-on: ubuntu-latest
@@ -48,17 +51,20 @@ jobs:
           name: perf-results-${{ github.run_number }}
           path: perf-results.json
 
-      - name: Deploy to gh-pages
-        if: github.event_name == 'schedule'
+      # Global `gh-pages` CLI fails on GHA with:
+      # TypeError: The "path" argument must be of type string. Received undefined
+      # (find-cache-dir returns undefined under global npm install). Use the
+      # in-repo peaceiris action instead (same pattern as compliance.yaml).
+      - name: Prepare perf publish directory
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          # Install gh-pages
-          npm install -g gh-pages
-
-          # Create perf directory
           mkdir -p perf
+          cp perf-results.json "perf/$(date +%Y-%m-%d).json"
 
-          # Copy results with timestamp
-          cp perf-results.json perf/$(date +%Y-%m-%d).json
-
-          # Deploy to gh-pages branch
-          gh-pages --dist perf --add
+      - name: Deploy to gh-pages
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./perf
+          keep_files: true


### PR DESCRIPTION
## Summary
- Root cause: global `npm install -g gh-pages` fails on GHA with `TypeError: The "path" argument must be of type string. Received undefined` (`find-cache-dir` returns undefined under global install; run 29473421092).
- Replace with `peaceiris/actions-gh-pages@v3` (same pattern as `compliance.yaml`), `keep_files: true` to preserve prior dated results.
- Allow deploy on `workflow_dispatch` so the fix can be proven without waiting for nightly schedule.
- Add `permissions: contents: write` for the Pages push token.

## Test plan
- [ ] CI required checks green on PR
- [ ] After merge: `gh workflow run perf.yaml --ref main` and confirm Deploy to gh-pages succeeds
- [ ] Inventory reflects `perf.yaml` green