### PR TITLE
fix(ci): pass --offline in redteam-offline job

### DIFF
--- a/.github/workflows/redteam.yaml
+++ b/.github/workflows/redteam.yaml
@@ -24,8 +24,13 @@ jobs:
         run: pip install pyyaml requests
       - name: Run offline red-team scripts
         run: |
-          python tests/redteam/injection_runner.py --corpus tests/redteam/injection_corpus.jsonl --kernel-url http://127.0.0.1:8080 --output injection-results.json
-          python tests/redteam/abac_fuzz.py
+          # Job is offline-only: no kernel/gateway is started. Without --offline,
+          # connection failures look like universal BLOCKED and false-fail ALLOWED cases.
+          python tests/redteam/injection_runner.py \
+            --corpus tests/redteam/injection_corpus.jsonl \
+            --offline \
+            --output injection-results.json
+          python tests/redteam/abac_fuzz.py --offline
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- `redteam-offline` never starts a policy kernel, but `injection_runner.py` was invoked without `--offline`.
- Connection failures made every plan look BLOCKED, so expected-ALLOWED cases (injection_016–020) false-failed (15/20 pass).
- Pass `--offline` to both `injection_runner.py` and `abac_fuzz.py` (both already support it; job name/step text already say offline).

## Test plan
- [ ] CI required checks green
- [ ] After merge: `gh workflow run redteam.yaml --ref main` and confirm `redteam-offline` succeeds