### PR TITLE
fix(ci): lazy-import aiohttp so redteam offline works

### DIFF
--- a/tests/redteam/abac_fuzz.py
+++ b/tests/redteam/abac_fuzz.py
@@ -12,12 +12,14 @@ import json
 import random
 import string
 import time
-from typing import Dict, List, Tuple, Optional
-import aiohttp
+from typing import TYPE_CHECKING, Dict, List, Tuple, Optional
 import hashlib
 from dataclasses import dataclass
 from concurrent.futures import ThreadPoolExecutor
 import logging
+
+if TYPE_CHECKING:
+    import aiohttp
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -251,7 +253,7 @@ class ABACFuzzTester:
         logger.info(f"Generated {len(self.test_cases)} test cases")
 
     async def execute_test_case(
-        self, session: aiohttp.ClientSession, test_case: TestCase
+        self, session: "aiohttp.ClientSession", test_case: TestCase
     ) -> TestResult:
         """Execute a single test case"""
         start_time = time.time()
@@ -335,6 +337,8 @@ class ABACFuzzTester:
 
     async def run_fuzz_tests(self) -> None:
         """Run all fuzz tests"""
+        import aiohttp
+
         logger.info("Starting ABAC fuzz tests...")
 
         connector = aiohttp.TCPConnector(limit=self.max_workers)


### PR DESCRIPTION
## Summary
- Follow-up to #201: `injection_runner --offline` passed, but `abac_fuzz.py` still imported `aiohttp` at module load and failed with `ModuleNotFoundError`.
- Lazy-import `aiohttp` only on the live fuzz path so offline CI needs no gateway deps.

## Test plan
- [ ] Local: `python tests/redteam/abac_fuzz.py --offline` exits 0
- [ ] After merge: `gh workflow run redteam.yaml --ref main` green