### PR TITLE
docs(internal): Wave 7 inventory 60/67 after #204

### DIFF
--- a/docs/internal/ci-inventory-latest.md
+++ b/docs/internal/ci-inventory-latest.md
@@ -1,6 +1,6 @@
 # CI workflow inventory (auto-generated)
 
-Generated: 2026-07-16T15:40:41Z UTC
+Generated: 2026-07-16T19:32:44Z UTC
 Repository: `SentinelOps-CI/provability-fabric` branch `main`
 
 ## Summary
@@ -9,39 +9,39 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 |--------|------:|
 | Total workflow files | 87 |
 | Gated (push/schedule on main) | 67 |
-| Green (last run success) | 51 |
-| Red (failure/cancelled/in progress) | 18 |
-| No run / unknown | 18 |
+| Green (last run success) | 60 |
+| Red (failure/cancelled/in progress) | 11 |
+| No run / unknown | 16 |
 
 ## Workflows
 
 | Workflow | Triggers | Last status | Gated | URL |
 |----------|----------|-------------|-------|-----|
-| `actionlint.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29503093069 |
+| `actionlint.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017221 |
 | `adapters-ci.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29477314927 |
 | `allowlist-sync.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706271 |
 | `art-benchmark.yaml` | workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399502401 |
-| `bench-nightly-criterion.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29509041247 |
+| `bench-nightly-criterion.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29513118624 |
 | `bench-swebench-smoke.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29482360310 |
-| `bench-swebench-stress-scheduled.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29181697304 |
-| `bench-swebench-unit.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29488165243 |
+| `bench-swebench-stress-scheduled.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29522474048 |
+| `bench-swebench-unit.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017320 |
 | `billing-test.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29473465754 |
 | `bundle-check.yaml` | pull_request | no_run | no | - |
 | `cargo-deny.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28631247789 |
 | `cert-validate.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279849 |
 | `chaos-nightly.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29473147086 |
-| `ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508974204 |
+| `ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017316 |
 | `ci-nightly-pytest.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29480168292 |
-| `ci-weekly-full.yml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29239884669 |
+| `ci-weekly-full.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29515858240 |
 | `cla-bot.yaml` | pull_request, workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27528984318 |
-| `codeql.yaml` | push, pull_request, schedule | **in_progress** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508974027 |
+| `codeql.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017343 |
 | `compliance.yaml` | release, workflow_dispatch | no_run | no | - |
 | `demo-e2e.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404745 |
 | `dependency-review.yml` | pull_request | no_run | no | - |
 | `dep-graph.yaml` | pull_request | no_run | no | - |
 | `dfa.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647153 |
-| `docs-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404720 |
-| `docs-deploy.yaml` | push | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404749 |
+| `docs-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29513118451 |
+| `docs-deploy.yaml` | push | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29513118621 |
 | `dr-cross.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29180887456 |
 | `edge-load.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417787429 |
 | `egress.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279890 |
@@ -59,17 +59,17 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | `loadtest.yaml` | pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399924626 |
 | `marketplace-e2e.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705631 |
 | `morph-replay.yml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279955 |
-| `multiarch-build.yaml` | push, pull_request, workflow_dispatch | **in_progress** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973857 |
+| `multiarch-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017101 |
 | `nightly-replay.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29472546438 |
 | `opa-test.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29489277608 |
-| `operational-excellence.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973849 |
+| `operational-excellence.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017096 |
 | `paper-conformance.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973676 |
 | `pcs-ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29477314965 |
-| `perf.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29473421092 |
-| `performance-gate.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973836 |
+| `perf.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29514836813 |
+| `performance-gate.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29513118372 |
 | `perf-proofmeter.yaml` | push, pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417776889 |
 | `pf-ci.yaml` | workflow_call | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677070943 |
-| `pf-core-schema-check.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973811 |
+| `pf-core-schema-check.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017064 |
 | `pf-cross-repo-consumer.yaml` | pull_request, schedule | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399838783 |
 | `pf-reusable-caller.yaml` | pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29475941844 |
 | `platform-cert-validate.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29472261494 |
@@ -85,8 +85,8 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | `proto-compat.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29472131307 |
 | `publish-updates.yaml` | push, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399543888 |
 | `rbac-test.yaml` | pull_request, workflow_dispatch | no_run | no | - |
-| `redteam.yaml` | pull_request, schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29179664746 |
-| `release.yaml` | push, workflow_dispatch | **no_run** | yes | - |
+| `redteam.yaml` | pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29520388261 |
+| `release.yaml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29528283470 |
 | `release-sbom.yml` | release | no_run | no | - |
 | `replay.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279862 |
 | `retrieval-gateway.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29410389588 |
@@ -96,31 +96,22 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | `reusable-ci-prepare.yml` | workflow_call | no_run | no | - |
 | `reusable-ci-rust.yml` | workflow_call | no_run | no | - |
 | `revocation-sync.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19400248470 |
-| `sbom-diff.yaml` | push, pull_request, release | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973720 |
-| `scorecards.yml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973899 |
+| `sbom-diff.yaml` | push, pull_request, release | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017070 |
+| `scorecards.yml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017180 |
 | `slo-gates.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29472182424 |
 | `spec-ai.yaml` | pull_request | no_run | no | - |
 | `standards-pin.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404740 |
-| `trust-fire-ga-test.yaml` | schedule, workflow_dispatch | **failure** | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29181636975 |
-| `verify-publish-bundle.yaml` | push, pull_request, workflow_dispatch | **no_run** | yes | - |
+| `trust-fire-ga-test.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29522471801 |
+| `verify-publish-bundle.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525078691 |
 | `wasm-scan.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29410389729 |
 
 ## Gated workflows not green
 
-- `bench-swebench-stress-scheduled.yaml (failure)`
-- `ci-weekly-full.yml (failure)`
-- `codeql.yaml (in_progress)`
 - `dr-cross.yaml (failure)`
 - `edge-load.yaml (failure)`
 - `loadtest.yaml (failure)`
-- `multiarch-build.yaml (in_progress)`
-- `perf.yaml (failure)`
 - `perf-proofmeter.yaml (failure)`
 - `pf-cross-repo-consumer.yaml (failure)`
 - `publish-updates.yaml (failure)`
-- `redteam.yaml (failure)`
-- `release.yaml (no_run)`
 - `revocation-sync.yaml (failure)`
-- `trust-fire-ga-test.yaml (failure)`
-- `verify-publish-bundle.yaml (no_run)`
 

--- a/docs/internal/remediation-tracker.md
+++ b/docs/internal/remediation-tracker.md
@@ -10,23 +10,23 @@ Maps findings **F01–F39** from [full-repo-audit-2026-07-01.md](full-repo-audit
 
 ## CI baseline (Wave 0 inventory)
 
-Captured via `powershell -File scripts/ci_workflow_inventory.ps1 -Markdown` (2026-07-15; requires `gh` CLI authenticated to repo). Full table: [ci-inventory-latest.md](ci-inventory-latest.md).
+Captured via `powershell -File scripts/ci_workflow_inventory.ps1 -Markdown` (2026-07-16; requires `gh` CLI authenticated to repo). Full table: [ci-inventory-latest.md](ci-inventory-latest.md).
 
 | Metric | Count |
 |--------|------:|
 | Total workflow files | 87 |
-| Gated (push/schedule on `main`) | 69 |
-| Latest run **success** | 39 |
-| Latest run **failure / in_progress / cancelled** | 30 |
-| No run / unknown (queued) | 18 |
+| Gated (push/schedule on `main`) | 67 |
+| Latest run **success** | 60 |
+| Latest run **failure / in_progress / cancelled** | 7 |
+| No run / unknown | 16 |
 
-**Green snapshot (39/69, 2026-07-15 @ `f4b0859e`):** includes `paper-conformance.yaml` ([29443718127](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29443718127)); replay cluster; security baseline; `integration.yaml`; related nightly lanes — see inventory for full list.
+**Green snapshot (60/67, 2026-07-16 @ `a844d8b0`):** includes `release.yaml`, `verify-publish-bundle.yaml`, `codeql.yaml`, multiarch, ops-excellence — see inventory for full list.
 
-**No run on main (gated):** `policy-build.yml`, `release.yaml`, `verify-publish-bundle.yaml` (awaiting trigger).
+**No run on main (gated):** none material — `release.yaml` and `verify-publish-bundle.yaml` greened via #204 + dispatch (2026-07-16).
 
 Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -File scripts/ci_workflow_inventory.ps1` (Windows).
 
-**Note:** **PR #136 + #144 merged** to `main` at `95bcd563` (2026-07-03). **PR #146 merged** 2026-07-02 (wasm-scan, retrieval-gateway Docker, CodeQL). **PR #151 merged** at `ee68659c` (2026-07-03, F21 compose postgres init). **PR #176 merged** at `f4b0859e` (2026-07-15, F24 paper-conformance). Integration F10+F21 green on `main`; F24 closed (paper-conformance ×2 green). Next: multiarch GHCR/cache retry (PR #164 merged; last run red on Actions cache export). Wave 7 cluster triage: [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md).
+**Note:** **PR #204 merged** at `a844d8b0` (2026-07-16): release dry-run, verify-publish fixture, CodeQL JS disk. Inventory **60/67**. Prior: **PR #203** trust-fire + swebench stress; **PR #176** F24 paper-conformance. Wave 7 cluster triage: [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md).
 
 ---
 
@@ -132,7 +132,7 @@ Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -
 | Paper-conformance shadow mode | **DONE** (wired) | `paper-conformance.yaml` integration job sets `PF_SHADOW_MODE=1` |
 | Criterion `refresh_baseline` | **DONE** | Green ×3 @ `1ab0d2d5`; `bench/BASELINE.md` recorded; #197/#198 |
 
-**Still pending main CI proof:** multiarch (GHCR/Actions cache), `perf.yaml` / DR-AWS / stress / weekly-full cluster, 67/67 inventory ×2. Main @ `1ab0d2d5`; F23+F24 DONE — see [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md).
+**Still pending main CI proof:** 67/67 inventory ×2. Remaining gated reds (2026-07-16 @ `a844d8b0`, **60/67**): `dr-cross` (AWS); `disabled_inactivity` cluster (`edge-load`, `loadtest`, `perf-proofmeter`, `publish-updates`, `revocation-sync`, `pf-cross-repo-consumer`). See [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md).
 
 ---
 

--- a/docs/internal/wave7-post-merge-runbook.md
+++ b/docs/internal/wave7-post-merge-runbook.md
@@ -8,7 +8,31 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 
 ---
 
-## Status (2026-07-16 — Wave 7 / F23 closeout)
+## Status (2026-07-16 — Wave 7 / release + verify-publish + CodeQL)
+
+**Merged:** **PR #204** (release dry-run / missing-`CI_PAT` skip; verify-publish fixture `logs/`; CodeQL JS disk reclaim). **Main head:** `a844d8b0`. Inventory **60/67**.
+
+| Phase | Status | Evidence |
+|-------|--------|----------|
+| 0 — Merge gate | **DONE** | `a844d8b0` on `main` |
+| 1.4 Lean + paper | **DONE (F24)** | `paper-conformance` green ×2 @ `f4b0859e` |
+| 1.5 Bench + docs | **DONE (F23)** | `bench-nightly-criterion` green ×3 @ `1ab0d2d5` lineage |
+| 1.6 Remaining | **IN PROGRESS** | `release.yaml` dry-run green ×3 ([29525076387](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525076387)+); `verify-publish-bundle` green ×2 ([29525017061](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017061), [29525078691](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525078691)); `codeql.yaml` green @ tip ([29525017343](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017343)); multiarch + ops-excellence green @ tip |
+| **Next action** | **7 honest leftovers** | `dr-cross` (AWS creds); skip `disabled_inactivity`: `edge-load` / `loadtest` / `perf-proofmeter` / `publish-updates` / `revocation-sync` / `pf-cross-repo-consumer` unless re-enabled honestly |
+
+### Prior status (2026-07-16 — Wave 7 / trust-fire + swebench stress)
+
+**Merged:** **PR #203** (`trust-fire-ga-test` orchestrator smoke; `bench-swebench-stress-scheduled` mock fallback). **Main head:** `00b5257f`. Inventory **54/67**.
+
+| Phase | Status | Evidence |
+|-------|--------|----------|
+| 0 — Merge gate | **DONE** | `00b5257f` on `main` |
+| 1.4 Lean + paper | **DONE (F24)** | `paper-conformance` green ×2 @ `f4b0859e` |
+| 1.5 Bench + docs | **DONE (F23)** | `bench-nightly-criterion` green ×3 @ `1ab0d2d5` lineage |
+| 1.6 Remaining | **IN PROGRESS** | `trust-fire-ga-test` green [29522471801](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29522471801); `bench-swebench-stress-scheduled` green [29522474048](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29522474048); prior: `perf.yaml` / `redteam` green via #200–#202 |
+| **Next action** | **Next clear gated red** | Prefer `release.yaml` / `verify-publish-bundle.yaml` (`no_run`) or `dr-cross` (needs AWS creds); skip `disabled_inactivity` (`edge-load`/`loadtest`/`perf-proofmeter`/`publish-updates`/`revocation-sync`/`pf-cross-repo-consumer`) unless re-enabled honestly |
+
+### Prior status (2026-07-16 — Wave 7 / F23 closeout)
 
 **Merged:** **PR #197** (Criterion CI timeouts/overrides); **PR #198** (ring-buffer MPMC hang). **Main head:** `1ab0d2d5`. Inventory **51/67**.
 


### PR DESCRIPTION
## Summary
- Refresh CI inventory to **60/67** after PR #204 (release dry-run, verify-publish fixture, CodeQL disk).
- Update Wave 7 runbook + remediation tracker with tip `a844d8b0` and the seven remaining honest blockers.

## Test plan
- [x] Inventory regenerated via `ci_workflow_inventory.ps1 -Markdown`
- [ ] Docs-only PR merge gate green
