### PR TITLE
fix(ci): remove unreachable org/ci-workflows Dependabot dependency

### DIFF
--- a/.github/workflows/pf-cross-repo-consumer.yaml
+++ b/.github/workflows/pf-cross-repo-consumer.yaml
@@ -1,18 +1,49 @@
 name: Cross-Repo PF CI Consumer
 
-# Calls org/ci-workflows reusable workflow (external SaaS/org wiring). Cannot
-# pass without that org repo and historically failed as disabled_inactivity.
-# Kept as workflow_dispatch-only so inventory is not gated on an unachievable
-# path (same pattern as #194/#196). In-repo PF CI remains pf-reusable-caller /
-# pf-ci.yaml.
+# Documents the intended cross-repo consumer contract without referencing a
+# non-existent external repo. A prior placeholder
+# (`org/ci-workflows/.github/workflows/pf-ci.yaml@v1`) made Dependabot Updates
+# fail with git_dependencies_not_reachable.
+#
+# Real reusable PF CI lives in-repo at .github/workflows/pf-ci.yaml and is
+# exercised by pf-reusable-caller.yaml. This workflow only checks the local
+# reusable-workflow contract (no SaaS secrets, no Kind/TRUST-FIRE run).
 on:
+  push:
+    paths:
+      - ".github/workflows/pf-ci.yaml"
+      - ".github/workflows/pf-cross-repo-consumer.yaml"
+      - ".github/workflows/pf-reusable-caller.yaml"
+  pull_request:
+    paths:
+      - ".github/workflows/pf-ci.yaml"
+      - ".github/workflows/pf-cross-repo-consumer.yaml"
+      - ".github/workflows/pf-reusable-caller.yaml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  pf-ci:
-    uses: org/ci-workflows/.github/workflows/pf-ci.yaml@v1
-    with:
-      pr_number: ${{ github.event.pull_request.number || '' }}
-      run_phases: "2,3,6"
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  consumer-contract:
+    name: Verify in-repo PF CI consumer contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Assert reusable PF CI workflow contract
+        run: |
+          set -euo pipefail
+          test -f .github/workflows/pf-ci.yaml
+          grep -q '^on:' .github/workflows/pf-ci.yaml
+          grep -q 'workflow_call:' .github/workflows/pf-ci.yaml
+          grep -q 'name: PF CI Workflow' .github/workflows/pf-ci.yaml
+          # Callers must use the in-repo reusable workflow, not a fake org URL.
+          grep -q 'uses: \./\.github/workflows/pf-ci.yaml' .github/workflows/pf-reusable-caller.yaml
+          if grep -R --include='*.yml' --include='*.yaml' -n 'org/ci-workflows' .github/workflows/; then
+            echo "ERROR: unreachable org/ci-workflows placeholder must not appear in workflow files (breaks Dependabot)."
+            exit 1
+          fi
+          echo "PF CI consumer contract OK (in-repo reusable workflow only)."

--- a/.github/workflows/pf-cross-repo-consumer.yaml
+++ b/.github/workflows/pf-cross-repo-consumer.yaml
@@ -1,8 +1,8 @@
 name: Cross-Repo PF CI Consumer
 
 # Documents the intended cross-repo consumer contract without referencing a
-# non-existent external repo. A prior placeholder
-# (`org/ci-workflows/.github/workflows/pf-ci.yaml@v1`) made Dependabot Updates
+# non-existent external reusable-workflow repository. A prior placeholder
+# uses: line (fictional OWNER/ci-workflows pf-ci@v1) made Dependabot Updates
 # fail with git_dependencies_not_reachable.
 #
 # Real reusable PF CI lives in-repo at .github/workflows/pf-ci.yaml and is
@@ -40,10 +40,11 @@ jobs:
           grep -q '^on:' .github/workflows/pf-ci.yaml
           grep -q 'workflow_call:' .github/workflows/pf-ci.yaml
           grep -q 'name: PF CI Workflow' .github/workflows/pf-ci.yaml
-          # Callers must use the in-repo reusable workflow, not a fake org URL.
-          grep -q 'uses: \./\.github/workflows/pf-ci.yaml' .github/workflows/pf-reusable-caller.yaml
-          if grep -R --include='*.yml' --include='*.yaml' -n 'org/ci-workflows' .github/workflows/; then
-            echo "ERROR: unreachable org/ci-workflows placeholder must not appear in workflow files (breaks Dependabot)."
+          # Callers must use the in-repo reusable workflow, not a fake external URL.
+          grep -q 'uses: ./.github/workflows/pf-ci.yaml' .github/workflows/pf-reusable-caller.yaml
+          # Dependabot resolves uses: git deps; ban unreachable placeholder hosts.
+          if grep -R --include='*.yml' --include='*.yaml' -nE '^\s*uses:\s*org/ci-workflows/' .github/workflows/; then
+            echo "ERROR: unreachable uses: org/ci-workflows/... must not appear in workflow files (breaks Dependabot)."
             exit 1
           fi
           echo "PF CI consumer contract OK (in-repo reusable workflow only)."

--- a/docs/reference/ci-reference.md
+++ b/docs/reference/ci-reference.md
@@ -120,23 +120,16 @@ jobs:
 
 ## Cross-repo usage
 
-Publish the reusable workflow to a central repository (e.g., `org/ci-workflows`) under `.github/workflows/pf-ci.yaml` and tag a version (e.g., `v1`). Then call it:
+In this repository, callers must use the **in-repo** reusable workflow
+(`.github/workflows/pf-ci.yaml`). See `pf-reusable-caller.yaml` and the
+contract smoke in `pf-cross-repo-consumer.yaml`.
 
-```yaml
-name: Cross-Repo PF CI Consumer
-on:
-  pull_request:
-  schedule:
-    - cron: "0 3 * * *"
-jobs:
-  pf-ci:
-    uses: org/ci-workflows/.github/workflows/pf-ci.yaml@v1
-    with:
-      pr_number: ${{ github.event.pull_request.number || '' }}
-      run_phases: "2,3,6"
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
+Do **not** put unreachable placeholder `uses:` URLs (for example a fictional
+`OWNER/ci-workflows` repo) into workflow files: GitHub Dependabot treats those
+as git dependencies and fails Updates with `git_dependencies_not_reachable`.
+
+If a future shared org publishes a real reusable copy, pin that live repository
+and tag explicitly after it exists; until then keep the in-repo `uses:` path.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace placeholder `uses: org/ci-workflows/...` in `pf-cross-repo-consumer.yaml` with an in-repo PF CI contract smoke (no SaaS secrets).
- Document that callers must use `.github/workflows/pf-ci.yaml`; unreachable placeholder URLs break Dependabot Updates (`git_dependencies_not_reachable`).
- Path-filtered push/PR so the smoke can go green without gating on Kind/TRUST-FIRE.

## Test plan
- [ ] PR checks pass
- [ ] After merge, `pf-cross-repo-consumer` succeeds on main
- [ ] Dependabot Updates no longer reports `org/ci-workflows` unreachable