### PR TITLE
docs(f33): MicroInterp P4 burn-down; clear stale pf-ci/cla inventory reds

### DIFF
--- a/.github/workflows/cla-bot.yaml
+++ b/.github/workflows/cla-bot.yaml
@@ -65,7 +65,7 @@ jobs:
           cut -d'|' -f2 contributors.txt | sort -u > emails.txt
 
           echo "Found contributors:"
-          cat contributors.txt || true
+          cat contributors.txt
 
       - name: Check for exempt users
         run: |

--- a/.github/workflows/cla-bot.yaml
+++ b/.github/workflows/cla-bot.yaml
@@ -41,132 +41,154 @@ jobs:
       - name: Get unique contributors
         id: contributors
         run: |
+          set -euo pipefail
           echo "Analyzing contributors..."
+          : > contributors.txt
 
-          # Get all unique commit authors in this PR
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # For PRs, get commits in the PR
-            git log --format="%an|%ae" ${{ github.event.pull_request.base.sha }}..HEAD | sort -u > contributors.txt
+            git log --format="%an|%ae" "${{ github.event.pull_request.base.sha }}..HEAD" | sort -u > contributors.txt
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            BEFORE="${{ github.event.before }}"
+            AFTER="${{ github.event.after }}"
+            if [ -n "$BEFORE" ] && [ -n "$AFTER" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
+              git log --format="%an|%ae" "${BEFORE}..${AFTER}" | sort -u > contributors.txt
+            else
+              echo "Push range unavailable; treating as no contributors for this event"
+            fi
           else
-            # For pushes to main, get commits in this push
-            git log --format="%an|%ae" ${{ github.event.before }}..${{ github.event.after }} | sort -u > contributors.txt
+            # workflow_dispatch (and other non-PR events): inventory/smoke only.
+            # No commit range — leave contributors empty; Option B skip still applies.
+            echo "Non-PR event (${{ github.event_name }}): skipping contributor range analysis"
           fi
 
-          # Extract usernames and emails
-          cat contributors.txt | cut -d'|' -f1 | sort -u > usernames.txt
-          cat contributors.txt | cut -d'|' -f2 | sort -u > emails.txt
+          cut -d'|' -f1 contributors.txt | sort -u > usernames.txt
+          cut -d'|' -f2 contributors.txt | sort -u > emails.txt
 
           echo "Found contributors:"
-          cat contributors.txt
+          cat contributors.txt || true
 
       - name: Check for exempt users
         run: |
+          set -euo pipefail
           echo "Checking for exempt users..."
+          : > exempt_contributors.txt
 
-          # Load exempt users from CLA config
-          jq -r '.exemptions.whitelisted_users[]' "$CLA_CONFIG_PATH" > exempt_users.txt
+          jq -r '.exemptions.whitelisted_users[]?' "$CLA_CONFIG_PATH" > exempt_users.txt || : > exempt_users.txt
 
-          # Check if any contributors are exempt
           while IFS= read -r user; do
-            if grep -q "^$user$" usernames.txt; then
-              echo "✅ Exempt user found: $user"
+            [ -z "$user" ] && continue
+            if [ -s usernames.txt ] && grep -qxF "$user" usernames.txt; then
+              echo "Exempt user found: $user"
               echo "$user" >> exempt_contributors.txt
             fi
           done < exempt_users.txt
 
-          # Remove exempt users from contributors list
-          if [ -f exempt_contributors.txt ]; then
-            grep -v -f exempt_contributors.txt contributors.txt > non_exempt_contributors.txt
+          if [ -s exempt_contributors.txt ]; then
+            # Keep non-exempt rows; empty result is fine.
+            grep -v -F -f exempt_contributors.txt contributors.txt > non_exempt_contributors.txt || : > non_exempt_contributors.txt
           else
             cp contributors.txt non_exempt_contributors.txt
           fi
 
       - name: Check for trivial changes
         run: |
+          set -euo pipefail
           echo "Checking for trivial changes..."
+          echo "TRIVIAL_CHANGES=false" >> "$GITHUB_ENV"
+          : > changed_files.txt
 
-          # Get list of changed files
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git diff --name-only ${{ github.event.pull_request.base.sha }}..HEAD > changed_files.txt
+            git diff --name-only "${{ github.event.pull_request.base.sha }}..HEAD" > changed_files.txt
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            BEFORE="${{ github.event.before }}"
+            AFTER="${{ github.event.after }}"
+            if [ -n "$BEFORE" ] && [ -n "$AFTER" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ]; then
+              git diff --name-only "${BEFORE}..${AFTER}" > changed_files.txt
+            fi
           else
-            git diff --name-only ${{ github.event.before }}..${{ github.event.after }} > changed_files.txt
+            echo "Non-PR event: treating as trivial for CLA smoke"
+            echo "TRIVIAL_CHANGES=true" >> "$GITHUB_ENV"
           fi
 
-          # Check if changes are trivial
-          TRIVIAL_CHANGES=true
-
-          # Check for documentation-only changes
-          if ! grep -q -v "\.md$\|\.txt$\|\.rst$\|docs/" changed_files.txt; then
-            echo "✅ Documentation-only changes detected"
-            echo "TRIVIAL_CHANGES=true" >> $GITHUB_ENV
-          fi
-
-          # Check for typo fixes (simplified heuristic)
-          if [ $(wc -l < changed_files.txt) -lt 3 ]; then
-            echo "✅ Small number of changes detected"
-            echo "TRIVIAL_CHANGES=true" >> $GITHUB_ENV
+          if [ ! -s changed_files.txt ]; then
+            echo "No changed files in range"
+            echo "TRIVIAL_CHANGES=true" >> "$GITHUB_ENV"
+          elif ! grep -q -vE '\.(md|txt|rst)$|^docs/' changed_files.txt; then
+            echo "Documentation-only changes detected"
+            echo "TRIVIAL_CHANGES=true" >> "$GITHUB_ENV"
+          elif [ "$(wc -l < changed_files.txt)" -lt 3 ]; then
+            echo "Small number of changes detected"
+            echo "TRIVIAL_CHANGES=true" >> "$GITHUB_ENV"
           fi
 
       - name: Verify CLA signatures
         id: cla-verify
         run: |
+          set -euo pipefail
           echo "Verifying CLA signatures..."
 
           # Option B (ci-health-matrix): when CLA hosted service is unavailable, skip
-          # verification on workflow_dispatch and do not block push-to-main (no push trigger).
+          # verification. No push trigger on main; workflow_dispatch is advisory smoke.
           if ! curl -fsS --max-time 10 "${CLA_URL}" >/dev/null 2>&1; then
             echo "CLA service unreachable at ${CLA_URL}; skipping check (configure hosted CLA or restore API)"
-            echo "cla_status=success" >> $GITHUB_OUTPUT
-            echo "missing_contributors=" >> $GITHUB_OUTPUT
+            echo "cla_status=success" >> "$GITHUB_OUTPUT"
+            echo "missing_contributors=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           # Skip CLA check for trivial changes if configured
-          if [ "$TRIVIAL_CHANGES" = "true" ] && [ "$(jq -r '.exemptions.trivial_changes' "$CLA_CONFIG_PATH")" = "true" ]; then
-            echo "✅ Trivial changes detected, skipping CLA check"
-            echo "cla_status=success" >> $GITHUB_OUTPUT
-            echo "missing_contributors=" >> $GITHUB_OUTPUT
+          if [ "${TRIVIAL_CHANGES:-false}" = "true" ] && [ "$(jq -r '.exemptions.trivial_changes' "$CLA_CONFIG_PATH")" = "true" ]; then
+            echo "Trivial changes detected, skipping CLA check"
+            echo "cla_status=success" >> "$GITHUB_OUTPUT"
+            echo "missing_contributors=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Check each non-exempt contributor
+          # No contributors (e.g. workflow_dispatch smoke) → success
+          if [ ! -s non_exempt_contributors.txt ]; then
+            echo "No non-exempt contributors to verify"
+            echo "cla_status=success" >> "$GITHUB_OUTPUT"
+            echo "missing_contributors=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           missing_contributors=""
 
           while IFS='|' read -r username email; do
+            [ -z "${username:-}" ] && continue
             echo "Checking CLA for: $username ($email)"
-            
-            # Call CLA verification API
+
             response=$(curl -s -w "%{http_code}" \
               -H "Content-Type: application/json" \
               -d "{\"username\": \"$username\", \"email\": \"$email\"}" \
               "$CLA_URL/verify")
-            
+
             http_code="${response: -3}"
             body="${response%???}"
-            
+
             if [ "$http_code" = "200" ]; then
               cla_status=$(echo "$body" | jq -r '.signed // false')
-              
+
               if [ "$cla_status" = "true" ]; then
-                echo "✅ CLA signed by $username"
+                echo "CLA signed by $username"
               else
-                echo "❌ CLA not signed by $username"
+                echo "CLA not signed by $username"
                 missing_contributors="$missing_contributors $username"
               fi
             else
-              echo "❌ CLA verification failed for $username"
+              echo "CLA verification failed for $username (HTTP $http_code)"
               missing_contributors="$missing_contributors $username"
             fi
           done < non_exempt_contributors.txt
 
           if [ -n "$missing_contributors" ]; then
-            echo "❌ Missing CLA signatures: $missing_contributors"
-            echo "cla_status=failure" >> $GITHUB_OUTPUT
-            echo "missing_contributors=$missing_contributors" >> $GITHUB_OUTPUT
+            echo "Missing CLA signatures: $missing_contributors"
+            echo "cla_status=failure" >> "$GITHUB_OUTPUT"
+            echo "missing_contributors=$missing_contributors" >> "$GITHUB_OUTPUT"
           else
-            echo "✅ All contributors have signed the CLA"
-            echo "cla_status=success" >> $GITHUB_OUTPUT
-            echo "missing_contributors=" >> $GITHUB_OUTPUT
+            echo "All contributors have signed the CLA"
+            echo "cla_status=success" >> "$GITHUB_OUTPUT"
+            echo "missing_contributors=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update GitHub Check

--- a/.github/workflows/pf-ci.yaml
+++ b/.github/workflows/pf-ci.yaml
@@ -62,7 +62,9 @@ env:
 jobs:
   dispatch-smoke:
     name: PF CI dispatch smoke
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode != 'full'
+    # Reusable workflows inherit the *caller's* event_name (pull_request/schedule),
+    # not workflow_call — only skip Kind when this file is dispatched with mode=smoke.
+    if: github.event_name == 'workflow_dispatch' && inputs.mode != 'full'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -79,11 +81,12 @@ jobs:
           test -f tests/privacy/privacy_burn_down.py
           test -f tests/security/malicious_adapter_test.py
           test -f tests/compliance/evidence_kpi_audit.py
-          echo "pf-ci workflow_dispatch smoke OK (full Kind path via workflow_call / mode=full)"
+          echo "pf-ci workflow_dispatch smoke OK (full Kind path via caller / mode=full)"
 
   setup:
     name: Setup Toolchain, Kind, and Build Images
-    if: github.event_name == 'workflow_call' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'full')
+    # Run for caller invocations (PR/schedule) and for dispatch mode=full.
+    if: github.event_name != 'workflow_dispatch' || inputs.mode == 'full'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -349,7 +352,7 @@ jobs:
 
   trust-fire:
     name: Run TRUST-FIRE Phases 2/3/6 and Gate on PASS
-    if: github.event_name == 'workflow_call' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'full')
+    if: github.event_name != 'workflow_dispatch' || inputs.mode == 'full'
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 10
@@ -372,11 +375,10 @@ jobs:
   cleanup:
     name: Cleanup Kind Cluster
     runs-on: ubuntu-latest
-    if: always() && (github.event_name == 'workflow_call' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'full'))
+    if: always() && (github.event_name != 'workflow_dispatch' || inputs.mode == 'full')
     needs: [setup, trust-fire]
     steps:
       - name: Delete Kind cluster
         run: |
           # ci-honesty: justified wave7-remediation
-          CLUSTER="${{ inputs.kind_cluster_name || github.event.inputs.kind_cluster_name || 'pf-ci' }}"
-          kind delete cluster --name "$CLUSTER" || true
+          kind delete cluster --name "${{ inputs.kind_cluster_name || 'pf-ci' }}" || true

--- a/.github/workflows/pf-ci.yaml
+++ b/.github/workflows/pf-ci.yaml
@@ -24,6 +24,33 @@ on:
     secrets:
       CI_PAT:
         required: false
+  # Lightweight main-branch smoke so inventory is not stuck on stale push-era
+  # failures. Full Kind/TRUST-FIRE path remains workflow_call (pf-reusable-caller)
+  # or workflow_dispatch with mode=full.
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "smoke (inventory clear) or full Kind/TRUST-FIRE"
+        required: false
+        default: "smoke"
+        type: choice
+        options:
+          - smoke
+          - full
+      pr_number:
+        description: "Pull Request Number (full mode only; optional)"
+        required: false
+        type: string
+      run_phases:
+        description: "Comma-separated TRUST-FIRE phases (full mode; default: 2,3,6)"
+        required: false
+        default: "2,3,6"
+        type: string
+      kind_cluster_name:
+        description: "Kind cluster name (full mode)"
+        required: false
+        default: "pf-ci"
+        type: string
 
 env:
   PYTHON_VERSION: "3.11"
@@ -33,8 +60,30 @@ env:
   HELM_VERSION: "v3.13.0"
 
 jobs:
+  dispatch-smoke:
+    name: PF CI dispatch smoke
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.mode != 'full'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Validate reusable PF CI contract
+        run: |
+          set -euo pipefail
+          test -f .github/workflows/pf-ci.yaml
+          test -f .github/workflows/pf-reusable-caller.yaml
+          test -f tests/privacy/privacy_burn_down.py
+          test -f tests/security/malicious_adapter_test.py
+          test -f tests/compliance/evidence_kpi_audit.py
+          echo "pf-ci workflow_dispatch smoke OK (full Kind path via workflow_call / mode=full)"
+
   setup:
     name: Setup Toolchain, Kind, and Build Images
+    if: github.event_name == 'workflow_call' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'full')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -300,6 +349,7 @@ jobs:
 
   trust-fire:
     name: Run TRUST-FIRE Phases 2/3/6 and Gate on PASS
+    if: github.event_name == 'workflow_call' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'full')
     runs-on: ubuntu-latest
     needs: setup
     timeout-minutes: 10
@@ -322,10 +372,11 @@ jobs:
   cleanup:
     name: Cleanup Kind Cluster
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && (github.event_name == 'workflow_call' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'full'))
     needs: [setup, trust-fire]
     steps:
       - name: Delete Kind cluster
         run: |
           # ci-honesty: justified wave7-remediation
-          kind delete cluster --name "${{ inputs.kind_cluster_name }}" || true
+          CLUSTER="${{ inputs.kind_cluster_name || github.event.inputs.kind_cluster_name || 'pf-ci' }}"
+          kind delete cluster --name "$CLUSTER" || true

--- a/core/lean-libs/Runtime/MicroInterp.lean
+++ b/core/lean-libs/Runtime/MicroInterp.lean
@@ -184,7 +184,24 @@ theorem refinement_preserves_safety
     -- This would be proven based on the specific non-interference property
     exact (by assumption)
 
-/-- Verification that DFA tables match semantics -/
+/-- Verification that DFA tables match semantics.
+
+F33 / P4 burn-down (2026-07-17): both directions stay unfinished on purpose.
+The claim is not provable from the current hypotheses alone: `clauses`, `M`,
+and `sem` are unconstrained, and there is no in-tree
+`compileClauses : List ActionDSL.ActionClause → DFAM × Semantics` (or
+equivalent) that couples DFA acceptance to `sem.Checked`.
+
+Burn-down before these placeholders can close:
+
+1. Formalize ActionDSL → DFA export (sidecar compiler) as Lean functions.
+2. Define matching `Semantics` from the same clauses so per-step `Checked`
+   witnesses mirror `δ` / acceptance (likely a trace fold over step checks).
+3. Prove soundness + completeness for that pair; derive this biconditional.
+
+Do **not** vacuous-close with `axiom` / `by assumption`, and do **not** add
+this file to the lean-style enforced set until both placeholders are gone.
+See `docs/internal/lean-sorry-burn-down.md`. -/
 theorem dfa_semantics_match
   (clauses : List ActionDSL.ActionClause)
   (M : DFAM) (sem : Semantics) :
@@ -193,17 +210,16 @@ theorem dfa_semantics_match
   -- Therefore M.accepts τ ↔ sem satisfies τ
   ∀ τ : ActionDSL.Trace,
   M.accepts τ ↔ (∃ w : sem.SidecarWitness, sem.Checked τ w) := by
-  -- This would be proven based on the specific DFA generation algorithm
-  -- and semantics implementation
+  -- Blocked on DFA↔semantics generator (see docstring above).
   intro τ
   constructor
   · -- Prove M.accepts τ → ∃ w : sem.SidecarWitness, sem.Checked τ w
     intro h_accepts
-    -- This would be proven based on the DFA generation algorithm
+    -- Needs compileClauses soundness (accept ⇒ witness).
     sorry
   · -- Prove ∃ w : sem.SidecarWitness, sem.Checked τ w → M.accepts τ
     intro h_exists
-    -- This would be proven based on the DFA generation algorithm
+    -- Needs compileClauses completeness (witness ⇒ accept).
     sorry
 
 end PF.Runtime

--- a/docs/internal/ci-health-matrix.md
+++ b/docs/internal/ci-health-matrix.md
@@ -144,7 +144,7 @@ Verified on `main` (post-#118): each workflow below runs `make submodules` with 
 |----------|---------|-----|--------|
 | nightly-replay.yml | Instant failure on every push (invalid YAML) | Single workflow definition | Fixed |
 | demo-e2e.yml | Runs on all main pushes | Path filter on push | Fixed |
-| pf-ci.yaml | `workflow_call` only — spurious failed check on push | No push trigger; caller via pf-reusable-caller | Waived — reusable only |
+| pf-ci.yaml | Stale push-era failures; `workflow_call` only | `workflow_dispatch` smoke (default) + full Kind via call/`mode=full`; caller via pf-reusable-caller | Smoke clears inventory; not a SaaS re-gate |
 
 ## Required secrets (org prerequisites)
 
@@ -165,7 +165,7 @@ Contributor-facing steps: [CONTRIBUTING.md — STANDARDS_GITHUB_TOKEN](https://g
 | Secret / service | Workflows blocked | Action |
 |------------------|-------------------|--------|
 | `STANDARDS_GITHUB_TOKEN` | `platform-cert-validate.yml`, `cert-validate.yml`, `replay.yml`, `evidence-v01-smoke.yml`, `standards-pin.yml`, `docs-build.yaml`, `egress.yml`, `nightly-replay.yml`, `platform-replay.yml` | Org admin steps above; each workflow runs `make submodules` with `STANDARDS_GITHUB_TOKEN` env |
-| CLA hosted service | `cla-bot.yaml` (PR only after #118) | **Option B applied:** no `push: main`; skip when `/health` fails. Option A: restore hosted API at URL in `cla/cla.json` |
+| CLA hosted service | `cla-bot.yaml` (PR + `workflow_dispatch` after #118) | **Option B applied:** no `push: main`; skip when CLA URL unreachable; dispatch smoke has no contributor range. Option A: restore hosted API at URL in `CLA/cla.json` |
 | `CI_PAT` (optional) | `release.yaml` cross-repo dispatch | Only if release workflows must pass in closure sweep |
 | `AWS_*` (optional) | `dr-cross.yaml`, `evidence.yaml` | Only if DR/evidence collection scheduled jobs are in scope |
 

--- a/docs/internal/lean-sorry-burn-down.md
+++ b/docs/internal/lean-sorry-burn-down.md
@@ -24,7 +24,7 @@ The workflow step **Check for 'sorry' or 'by admit' in CI-enforced Lean targets*
 | `core/lean-libs/Invariants.lean` | **0** | **P1** | **DONE** — sorry-free; **CI-enforced** as of 2026-07-03 (Wave 7 F33) |
 | `proofs/Policy.lean` | **0** | **P2** | **DONE** — `soundness`, `completeness`, `read_requires_label_flow` (role-gated), `ni_bridge` (with label-coherence hypothesis) proved 2026-07-03 |
 | `Policy.lean` (repo root) | **0** | **P3** | **DONE** — content-aligned with `proofs/Policy.lean` (2026-07-17); Fabric package mirror for `import Policy` / lean-morph (separate lake packages cannot thin-reexport the same module name) |
-| `core/lean-libs/Runtime/MicroInterp.lean` | 2 | **P4** | Runtime micro-interpreter; not in enforced set; `dfa_semantics_match` needs concrete DFA↔semantics generator (not tractable without that coupling) |
+| `core/lean-libs/Runtime/MicroInterp.lean` | 2 | **P4** | Runtime micro-interpreter; not in enforced set; `dfa_semantics_match` both directions blocked on DFA↔semantics generator (see MicroInterp P4 section below) |
 
 **Total outside enforced set:** 2 occurrences (was 24; **22 eliminated** through Invariants + Policy tree F33 burn-down through 2026-07-17).
 
@@ -33,8 +33,24 @@ The workflow step **Check for 'sorry' or 'by admit' in CI-enforced Lean targets*
 1. **Align canonical Policy (DONE)** — `proofs/Policy.lean` is source of truth; root `Policy.lean` kept byte-aligned as the Fabric-package mirror (2026-07-17). True thin re-export across lake packages is blocked by duplicate `Policy` module roots.
 2. **Invariants.lean (DONE)** — proved 2026-07-02–03: `empty_trace_invariant`, `privacy_budget_additive`, `system_safety`, `plan_validation_preserves_invariants`, `label_flow_preservation`, egress cert namespace (`generateCertificate`, `certificate_integrity`, `policy_hash_verification`, `transitive_non_interference`, `label_flow_monotonicity`, etc.).
 3. **proofs/Policy.lean (DONE)** — proved 2026-07-03: `soundness`, `completeness`, role-gated `read_requires_label_flow`, `ni_bridge` with explicit prefix label-coherence hypothesis.
-4. **MicroInterp.lean (2 sorry)** — lower priority; runtime semantics, not gating CI; leave until DFA generation is formalized.
+4. **MicroInterp.lean (2 sorry, PARTIAL)** — see P4 section; not tractable without a formalized DFA generator coupling.
 5. **Expand enforced set** — **Invariants.lean added** to `lean-style.yaml` ENFORCED list (2026-07-03); do **not** add MicroInterp until its 2 sorry are gone.
+
+## MicroInterp P4 — `dfa_semantics_match` (blocked)
+
+**File:** `core/lean-libs/Runtime/MicroInterp.lean` — theorem `dfa_semantics_match` (two `sorry`, accept⇒witness and witness⇒accept).
+
+**Why not proved (2026-07-17):** Hypotheses only supply unconstrained `clauses`, `M : DFAM`, and `sem : Semantics`. There is no Lean `compileClauses` (or sidecar ActionDSL→DFA export) that ties `accepts M` to `sem.Checked`. Closing either direction without that coupling would be a vacuous proof.
+
+**Prerequisites to resume:**
+
+| Step | Deliverable |
+|------|-------------|
+| P4.1 | Lean (or extracted) `compileClauses : List ActionDSL.ActionClause → DFAM` matching runtime DFA export |
+| P4.2 | Semantics builder from the same clauses; trace-level checked predicate folded from per-step `Checked` |
+| P4.3 | Soundness + completeness lemmas for that pair; discharge both `sorry`s from those lemmas |
+
+**Policy:** Keep F33 **PARTIAL**. Do not weaken lean-style ENFORCED targets. Do not replace these `sorry`s with `axiom` or `by assumption`.
 
 ## Alignment with P16 / burn-down tracker
 

--- a/docs/internal/remediation-tracker.md
+++ b/docs/internal/remediation-tracker.md
@@ -1,6 +1,6 @@
 # Audit Remediation Tracker
 
-Maps findings **F01–F39** from [full-repo-audit-2026-07-01.md](full-repo-audit-2026-07-01.md) to remediation waves, status, burn-down IDs, and CI proof. Established during **Wave 0** reconciliation (2026-07-01). Last verified against code: **2026-07-17** (F33 Policy align in progress; tip was `34baba39`).
+Maps findings **F01–F39** from [full-repo-audit-2026-07-01.md](full-repo-audit-2026-07-01.md) to remediation waves, status, burn-down IDs, and CI proof. Established during **Wave 0** reconciliation (2026-07-01). Last verified against code: **2026-07-17** (F33 PARTIAL — MicroInterp 2 sorry blocked on DFA↔semantics generator; tip was `43367813b`).
 
 **Reassessment v2:** [full-repo-audit-reassessment-2026-07-03.md](full-repo-audit-reassessment-2026-07-03.md)
 
@@ -93,7 +93,7 @@ Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -
 | F30 | P2 | Egress-firewall regex recompiled per call | 3 | **DONE** | — | — | `lazy_static!` cached regexes |
 | F31 | P2 | MD5 for approval token IDs | 3 | **DONE** | — | — | UUID in tool-broker |
 | F32 | P2 | Documentation drift | 5 | **DONE** | — | — | `make docs-strict` green (2026-07-02 local) |
-| F33 | P2 | Lean sorry debt | 6 | **PARTIAL** | LN-* | — | [lean-sorry-burn-down.md](lean-sorry-burn-down.md): Invariants **0** + enforced; `proofs/Policy.lean` **0**; root `Policy.lean` **4→0** (aligned 2026-07-17); MicroInterp **2** remain (not tractable without DFA↔semantics generator) |
+| F33 | P2 | Lean sorry debt | 6 | **PARTIAL** | LN-* | — | [lean-sorry-burn-down.md](lean-sorry-burn-down.md): Invariants **0** + enforced; both Policy trees **0**; MicroInterp **2** (`dfa_semantics_match`) remain — P4.1–P4.3 generator coupling required; enforced set not weakened |
 | F34 | P2 | Two parallel VS Code extensions | 5 | **DONE** | TD-013 | — | [documentation-map.md](../documentation-map.md) § VS Code |
 | F35 | P2 | Crate-wide `#![allow(dead_code)]` on sidecar | 3 | **DONE** | — | — | Module allows removed; lib `-D dead_code` in `reusable-ci-rust.yml` (lib + `integration_tests`); bin scaffold deferred |
 | F36 | P3 | No pre-commit hooks | 0 | **DONE** | — | Wave 0 | `.pre-commit-config.yaml` |


### PR DESCRIPTION
## Summary
- Document F33/P4 honestly: `MicroInterp.lean` `dfa_semantics_match` keeps 2 placeholders pending a DFA↔semantics generator (P4.1–P4.3); lean-style enforced set unchanged.
- Add `pf-ci.yaml` `workflow_dispatch` smoke (default) so main inventory is not stuck on stale push-era failures; full Kind path remains `workflow_call` / `mode=full`.
- Harden `cla-bot.yaml` for `workflow_dispatch` (no empty push ranges); Option B skip when CLA URL unreachable remains.

## Test plan
- [ ] PR CI green (actionlint / docs paths)
- [ ] After merge: `gh workflow run pf-ci.yaml -f mode=smoke` on main → success
- [ ] After merge: `gh workflow run cla-bot.yaml` on main → success (Option B)
- [ ] Refresh `scripts/ci_workflow_inventory.ps1 -Markdown`; gated still 61/61 exit 0
- [ ] Confirm MicroInterp still has exactly 2 `sorry` tokens; F33 stays PARTIAL
