### PR TITLE
docs(f33): inventory refresh after pf-ci/cla smoke clears

### DIFF
--- a/core/lean-libs/Runtime/MicroInterp.lean
+++ b/core/lean-libs/Runtime/MicroInterp.lean
@@ -201,7 +201,7 @@ Burn-down before these placeholders can close:
 
 Do **not** vacuous-close with `axiom` / `by assumption`, and do **not** add
 this file to the lean-style enforced set until both placeholders are gone.
-See `docs/internal/lean-sorry-burn-down.md`. -/
+See docs/internal F33 Lean burn-down tracker (P4 section). -/
 theorem dfa_semantics_match
   (clauses : List ActionDSL.ActionClause)
   (M : DFAM) (sem : Semantics) :

--- a/docs/internal/ci-inventory-latest.md
+++ b/docs/internal/ci-inventory-latest.md
@@ -1,6 +1,6 @@
 ﻿# CI workflow inventory (auto-generated)
 
-Generated: 2026-07-17T22:44:44Z UTC
+Generated: 2026-07-18T00:17:51Z UTC
 Repository: `SentinelOps-CI/provability-fabric` branch `main`
 
 ## Summary
@@ -9,17 +9,17 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 |--------|------:|
 | Total workflow files | 87 |
 | Gated (push/schedule on main) | 61 |
-| Green (last run success) | 61 |
-| Red (failure/cancelled/in progress) | 10 |
+| Green (last run success) | 63 |
+| Red (failure/cancelled/in progress) | 8 |
 | No run / unknown | 16 |
 
 ## Workflows
 
 | Workflow | Triggers | Last status | Gated | URL |
 |----------|----------|-------------|-------|-----|
-| `actionlint.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29615810135 |
+| `actionlint.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719858 |
 | `adapters-ci.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29477314927 |
-| `allowlist-sync.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706271 |
+| `allowlist-sync.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719881 |
 | `art-benchmark.yaml` | workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399502401 |
 | `bench-nightly-criterion.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29556889681 |
 | `bench-swebench-smoke.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29565200288 |
@@ -30,18 +30,18 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | `cargo-deny.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28631247789 |
 | `cert-validate.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279849 |
 | `chaos-nightly.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29556748331 |
-| `ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419795 |
+| `ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719983 |
 | `ci-nightly-pytest.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29563146130 |
 | `ci-weekly-full.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29515858240 |
-| `cla-bot.yaml` | pull_request, workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27528984318 |
-| `codeql.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419648 |
+| `cla-bot.yaml` | pull_request, workflow_dispatch | success | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620729102 |
+| `codeql.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719830 |
 | `compliance.yaml` | release, workflow_dispatch | no_run | no | - |
 | `demo-e2e.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404745 |
 | `dependency-review.yml` | pull_request | no_run | no | - |
 | `dep-graph.yaml` | pull_request | no_run | no | - |
 | `dfa.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647153 |
-| `docs-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419669 |
-| `docs-deploy.yaml` | push | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419673 |
+| `docs-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719825 |
+| `docs-deploy.yaml` | push | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719813 |
 | `dr-cross.yaml` | workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29180887456 |
 | `edge-load.yaml` | workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417787429 |
 | `egress.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279890 |
@@ -53,35 +53,35 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | `incident-test.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29556657458 |
 | `integration.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973757 |
 | `jwks-validate.yml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705444 |
-| `lean-morph.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419681 |
+| `lean-morph.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719899 |
 | `lean-offline.yaml` | workflow_dispatch | cancelled | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29491617791 |
-| `lean-style.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419642 |
+| `lean-style.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719805 |
 | `loadtest.yaml` | workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399924626 |
 | `marketplace-e2e.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705631 |
 | `morph-replay.yml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279955 |
-| `multiarch-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419613 |
+| `multiarch-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719874 |
 | `nightly-replay.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29556141894 |
 | `opa-test.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29489277608 |
-| `operational-excellence.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419643 |
-| `paper-conformance.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29556022920 |
+| `operational-excellence.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719826 |
+| `paper-conformance.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719839 |
 | `pcs-ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29477314965 |
 | `perf.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29556980152 |
 | `performance-gate.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29513118372 |
 | `perf-proofmeter.yaml` | workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19417776889 |
-| `pf-ci.yaml` | workflow_call | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/27677070943 |
-| `pf-core-schema-check.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419634 |
-| `pf-cross-repo-consumer.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29615810099 |
+| `pf-ci.yaml` | workflow_dispatch, workflow_call | success | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620728032 |
+| `pf-core-schema-check.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719884 |
+| `pf-cross-repo-consumer.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719836 |
 | `pf-reusable-caller.yaml` | pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29559243589 |
 | `platform-cert-validate.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29555866486 |
 | `platform-perf-smoke.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28639549722 |
 | `platform-replay.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29558106368 |
 | `policy-build.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647162 |
-| `policy-gates.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973752 |
+| `policy-gates.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719890 |
 | `policy-pr-proof.yml` | pull_request | no_run | no | - |
 | `pr-comments.yml` | pull_request | no_run | no | - |
 | `privacy-test.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973818 |
 | `proof-bot.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29556105465 |
-| `proof-fuzz.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29556158919 |
+| `proof-fuzz.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719835 |
 | `proto-compat.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29555744101 |
 | `publish-updates.yaml` | workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19399543888 |
 | `rbac-test.yaml` | pull_request, workflow_dispatch | no_run | no | - |
@@ -96,8 +96,8 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | `reusable-ci-prepare.yml` | workflow_call | no_run | no | - |
 | `reusable-ci-rust.yml` | workflow_call | no_run | no | - |
 | `revocation-sync.yaml` | workflow_dispatch | failure | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/19400248470 |
-| `sbom-diff.yaml` | push, pull_request, release | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419638 |
-| `scorecards.yml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29616419640 |
+| `sbom-diff.yaml` | push, pull_request, release | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719854 |
+| `scorecards.yml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719877 |
 | `slo-gates.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29555778731 |
 | `spec-ai.yaml` | pull_request | no_run | no | - |
 | `standards-pin.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404740 |

--- a/docs/internal/remediation-tracker.md
+++ b/docs/internal/remediation-tracker.md
@@ -1,6 +1,6 @@
 # Audit Remediation Tracker
 
-Maps findings **F01–F39** from [full-repo-audit-2026-07-01.md](full-repo-audit-2026-07-01.md) to remediation waves, status, burn-down IDs, and CI proof. Established during **Wave 0** reconciliation (2026-07-01). Last verified against code: **2026-07-17** (F33 PARTIAL — MicroInterp 2 sorry blocked on DFA↔semantics generator; tip was `43367813b`).
+Maps findings **F01–F39** from [full-repo-audit-2026-07-01.md](full-repo-audit-2026-07-01.md) to remediation waves, status, burn-down IDs, and CI proof. Established during **Wave 0** reconciliation (2026-07-01). Last verified against code: **2026-07-17** (F33 PARTIAL — MicroInterp 2 placeholders blocked on DFA↔semantics generator; tip `400be1de1` after #213).
 
 **Reassessment v2:** [full-repo-audit-reassessment-2026-07-03.md](full-repo-audit-reassessment-2026-07-03.md)
 
@@ -17,7 +17,7 @@ Captured via `powershell -File scripts/ci_workflow_inventory.ps1 -Markdown` (202
 | Total workflow files | 87 |
 | Gated (push/schedule on `main`) | 60 |
 | Latest run **success** | 60 |
-| Latest run **failure / cancelled** (ungated / PR-only) | 11 |
+| Latest run **failure / cancelled** (ungated / PR-only) | 8 |
 | No run / unknown | 16 |
 
 **Green snapshot (60/60 gated, inventory exit 0 ×2, 2026-07-16):** all push/schedule workflows green after **PR #206** honest ungating of seven SaaS/AWS leftovers; tip `b8b78b94` (#207 docs). See [ci-inventory-latest.md](ci-inventory-latest.md).


### PR DESCRIPTION
## Summary
- MicroInterp docstring path tweak so `sorry` inventory stays at exactly 2.
- Refresh `ci-inventory-latest.md` + tracker tip after #213 and successful main dispatch smokes for `pf-ci` / `cla-bot`.

## Test plan
- [ ] Wait for tip gated workflows green
- [ ] Inventory exit 0 ×2
- [ ] Confirm pf-ci + cla-bot last main status success
- [ ] F33 remains PARTIAL (MicroInterp 2)
