### PR TITLE
fix(ci): pin k6 to clear platform-perf-smoke tip red

### DIFF
--- a/.github/workflows/platform-perf-smoke.yml
+++ b/.github/workflows/platform-perf-smoke.yml
@@ -18,6 +18,10 @@ on:
       - ".github/workflows/platform-perf-smoke.yml"
   workflow_dispatch:
 
+env:
+  # Pin: do not query api.github.com/releases/latest (unauthenticated 403 flakiness).
+  K6_VERSION: "0.47.0"
+
 jobs:
   performance-smoke:
     runs-on: ubuntu-latest
@@ -28,7 +32,6 @@ jobs:
 
       - name: Install k6
         run: |
-          K6_VERSION=$(curl -fsSL https://api.github.com/repos/grafana/k6/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'].lstrip('v'))")
           curl -fsSL "https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz" -o /tmp/k6.tgz
           sudo tar -xzf /tmp/k6.tgz -C /usr/local/bin --strip-components=1 "k6-v${K6_VERSION}-linux-amd64/k6"
           k6 version

--- a/.github/workflows/slo-gates.yaml
+++ b/.github/workflows/slo-gates.yaml
@@ -19,6 +19,8 @@ env:
   BASE_URL: http://localhost:8080
   K6_BINARY: k6
   NODE_VERSION: '18'
+  # Pin: do not query api.github.com/releases/latest (unauthenticated 403 flakiness).
+  K6_VERSION: "0.47.0"
 
 jobs:
   # PR / main push smoke test - quick performance validation
@@ -33,7 +35,6 @@ jobs:
       
     - name: Install k6
       run: |
-        K6_VERSION=$(curl -fsSL https://api.github.com/repos/grafana/k6/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'].lstrip('v'))")
         curl -fsSL "https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz" -o /tmp/k6.tgz
         sudo tar -xzf /tmp/k6.tgz -C /usr/local/bin --strip-components=1 "k6-v${K6_VERSION}-linux-amd64/k6"
         k6 version
@@ -78,7 +79,6 @@ jobs:
 
     - name: Install k6
       run: |
-        K6_VERSION=$(curl -fsSL https://api.github.com/repos/grafana/k6/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'].lstrip('v'))")
         curl -fsSL "https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz" -o /tmp/k6.tgz
         sudo tar -xzf /tmp/k6.tgz -C /usr/local/bin --strip-components=1 "k6-v${K6_VERSION}-linux-amd64/k6"
         k6 version

--- a/docs/internal/remediation-tracker.md
+++ b/docs/internal/remediation-tracker.md
@@ -1,10 +1,10 @@
 # Audit Remediation Tracker
 
-Maps findings **F01–F39** from [full-repo-audit-2026-07-01.md](full-repo-audit-2026-07-01.md) to remediation waves, status, burn-down IDs, and CI proof. Established during **Wave 0** reconciliation (2026-07-01). Last verified against code: **2026-07-18** (F33 MicroInterp `dfa_semantics_match` proved — 0 sorry; Wave 8 re-gate of previously ungated smokes in progress).
+Maps findings **F01–F39** from [full-repo-audit-2026-07-01.md](full-repo-audit-2026-07-01.md) to remediation waves, status, burn-down IDs, and CI proof. Established during **Wave 0** reconciliation (2026-07-01). Last verified against code: **2026-07-18** (F33 MicroInterp `dfa_semantics_match` proved — 0 sorry; Wave 8 re-gates landed in **PR #215**; tip follow-up pins k6 to clear `platform-perf-smoke`).
 
 **Reassessment v2:** [full-repo-audit-reassessment-2026-07-03.md](full-repo-audit-reassessment-2026-07-03.md)
 
-**North-star:** inventory exit 0 on all push/schedule workflows (achieved **60/60** @ `7d48b3d4`, reconfirmed tip `b8b78b94`, 2026-07-16); trust chain fail-closed; burn-down reflects code reality. Do **not** claim literal 67/67.
+**North-star:** inventory exit 0 on all push/schedule workflows (Wave 7 **60/60** @ `7d48b3d4`; Wave 8 expands gated set via honest smokes — **not** literal 67/67); trust chain fail-closed; burn-down reflects code reality.
 
 ---
 
@@ -134,7 +134,7 @@ Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -
 
 **Wave 7 inventory gate:** **DONE** — inventory exit **0** twice on `main` @ `7d48b3d4` (**60/60** gated green); tip `b8b78b94` after #207. Phase 3+4: [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md).
 
-**Wave 8 revive (2026-07-18):** Re-gate previously abandoned leftovers with honest smokes — `art-benchmark`, `lean-offline` (Runtime smoke), `dr-cross` (secret-presence skip), `edge-load` / `loadtest` / `perf-proofmeter` (local mock + tiny k6/bench), `publish-updates` / `revocation-sync` (dry-run). Full SaaS/AWS paths stay dispatch-only. Do **not** claim literal 67/67.
+**Wave 8 revive (2026-07-18):** **PR #215** re-gated leftovers with honest smokes — `art-benchmark`, `lean-offline` (Runtime smoke), `dr-cross` (secret-presence skip), `edge-load` / `loadtest` / `perf-proofmeter` (local mock + tiny k6/bench), `publish-updates` / `revocation-sync` (dry-run). Tip inventory after #215: **69** gated; sole red was `platform-perf-smoke` (k6 `releases/latest` API 403) — fixed by pinning `K6_VERSION=0.47.0`. Full SaaS/AWS / vendored-mathlib offline paths stay dispatch-only. Do **not** claim literal 67/67.
 
 ---
 

--- a/docs/internal/wave7-post-merge-runbook.md
+++ b/docs/internal/wave7-post-merge-runbook.md
@@ -8,7 +8,21 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 
 ---
 
-## Status (2026-07-16 — Wave 7 / Phase 3+4 sign-off)
+## Status (2026-07-18 — Wave 8 revive + tip k6 pin)
+
+**Merged:** **PR #215** (F33 MicroInterp 0 sorry + re-gate 8 leftover smokes) @ `ad4fafd20`. Inventory after tip: **69 gated**, **1 red** (`platform-perf-smoke` — unauthenticated GitHub API 403 fetching k6 `releases/latest`). Follow-up pins `K6_VERSION=0.47.0` in `platform-perf-smoke.yml` + `slo-gates.yaml`.
+
+| Phase | Status | Evidence |
+|-------|--------|----------|
+| Wave 7 Phase 3+4 | **DONE** | Historical **60/60** @ `b8b78b94` (below) |
+| Wave 8 F33 | **DONE** | MicroInterp `dfa_semantics_match` proved; lean-style ENFORCED not weakened |
+| Wave 8 re-gates | **DONE** | `art-benchmark`, `lean-offline` smoke, `dr-cross` secret-skip, `edge-load`/`loadtest`/`perf-proofmeter`, `publish-updates`/`revocation-sync` green on tip |
+| Tip unblock | **IN PROGRESS** | Pin k6; clear `platform-perf-smoke`; refresh inventory to exit 0 |
+| **Next action** | **Merge k6 pin** | Then inventory exit 0; full SaaS/AWS + lean-offline-full remain dispatch-only |
+
+**Still deferred (honest; not demoted — dispatch/full paths):** live AWS DR (`dr-cross` with secrets), multi-region SaaS load, live registry publish, live revocation sync, vendored-mathlib `lean-offline-full`. Smoke/dry-run/skip paths are gated.
+
+### Prior status (2026-07-16 — Wave 7 / Phase 3+4 sign-off)
 
 **Merged:** **PR #206** (honest ungate) + **PR #207** (inventory docs). **Main tip:** `b8b78b94`. Inventory **60/60 gated green**, exit **0 ×2** (ceremony @ `7d48b3d4` 2026-07-16T20:48Z / 20:50Z; reconfirmed tip 2026-07-16T21:37Z / 21:40Z UTC). Phase 3 hardening proof table below (Phase D).
 
@@ -22,7 +36,7 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 | Phase E / Phase 4 | **DONE** | Tracker + closure + reassessment updated; F23/F24 **DONE**; **60/60** ×2; ungated list recorded |
 | **Next action** | **Optional** | Revive ungated workflows only with real SaaS/AWS smoke |
 
-**Honest ungated (not in gate; not proven in CI):** `dr-cross`, `edge-load`, `loadtest`, `perf-proofmeter`, `publish-updates`, `revocation-sync`, `pf-cross-repo-consumer` (+ prior #194/#196: `lean-offline`, `art-benchmark`).
+**Then-honest ungated (superseded by Wave 8 #215):** `dr-cross`, `edge-load`, `loadtest`, `perf-proofmeter`, `publish-updates`, `revocation-sync`, `pf-cross-repo-consumer` (+ prior #194/#196: `lean-offline`, `art-benchmark`).
 
 ### Prior status (2026-07-16 — Wave 7 / inventory gate closed @ `7d48b3d4`)
 


### PR DESCRIPTION
## Summary
- Pin `K6_VERSION=0.47.0` in `platform-perf-smoke.yml` and `slo-gates.yaml` so CI does not call unauthenticated `api.github.com/.../releases/latest` (403 flakiness that red-gated tip after #215).
- Refresh Wave 8 status in remediation tracker + wave7 runbook.

## Context
After PR #215, inventory was **69 gated / 1 red**: only `platform-perf-smoke` failed on k6 install. All eight Wave 8 revive workflows were already green.

## Test plan
- [ ] PR CI: Platform Performance Smoke Tests green
- [ ] PR CI: SLO Gates green when triggered
- [ ] After merge: `powershell -File scripts/ci_workflow_inventory.ps1` exit 0