### PR TITLE
ci(lean): harden lean-offline-full for schedule success

### DIFF
--- a/.github/workflows/lean-offline.yaml
+++ b/.github/workflows/lean-offline.yaml
@@ -1,10 +1,12 @@
 name: Lean Offline Build
 
 # Two tracks:
-# 1) lean-offline-smoke (gated): builds Runtime.MicroInterp (no mathlib imports)
-#    and checks F33 / enforced sorry policy. Proves offline-ish value without
-#    the cold-cache mathlib vendor hang that cancelled tip runs.
-# 2) lean-offline-full (dispatch-only): original vendored-mathlib offline path.
+# 1) lean-offline-smoke (gated on push/PR/schedule): builds Runtime.MicroInterp
+#    (no mathlib imports) and checks F33 / enforced sorry policy.
+# 2) lean-offline-full (schedule + dispatch full=true): vendored-mathlib offline
+#    path. Cache keys/paths intentionally share lean-style's mathlib cache so
+#    weekly schedule hits a warm vendor tree instead of hanging on cold
+#    `lake exe cache get` (historical tip cancels).
 on:
   push:
     branches: [main, develop]
@@ -12,6 +14,7 @@ on:
       - "**/*.lean"
       - "**/lakefile.lean"
       - "lean-toolchain"
+      - "scripts/vendor-mathlib.sh"
       - ".github/workflows/lean-offline.yaml"
   pull_request:
     branches: [main, develop]
@@ -19,6 +22,7 @@ on:
       - "**/*.lean"
       - "**/lakefile.lean"
       - "lean-toolchain"
+      - "scripts/vendor-mathlib.sh"
       - ".github/workflows/lean-offline.yaml"
   schedule:
     - cron: "30 5 * * 1"
@@ -33,6 +37,9 @@ on:
 concurrency:
   group: lean-offline-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  MATHLIB_COMMIT: a45ae63747140c1b2cbad9d46f518015c047047a
 
 jobs:
   lean-offline-smoke:
@@ -100,10 +107,14 @@ jobs:
           fi
           echo "No sorry/by admit in enforced targets or Runtime.MicroInterp"
 
+  # Full offline path: schedule (Monday) + explicit dispatch. Not on every lean
+  # push — cold vendor can exceed runner patience; smoke covers push/PR gates.
   lean-offline-full:
-    if: github.event_name == 'workflow_dispatch' && inputs.full == true
+    if: >
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.full == true)
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     name: "Lean Offline Full (vendored mathlib)"
     steps:
       - name: Checkout repository
@@ -111,6 +122,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Share lean-style cache key so weekly schedule restores a warm
+      # vendor/mathlib (.git + .lake). Historical cancels hung on cold
+      # `lake exe cache get` when .git was omitted from the cache paths.
       - name: Cache Lean toolchain and mathlib artifacts
         uses: actions/cache@v4
         with:
@@ -118,52 +132,64 @@ jobs:
             ~/.elan
             ~/.cache/lake
             vendor/mathlib/.lake
+            vendor/mathlib/.git
             core/lean-libs/.lake
             spec-templates/v1/proofs/.lake
             bundles/my-agent/proofs/.lake
             bundles/test-new-user-agent/proofs/.lake
-          key: lean-offline-${{ hashFiles('lean-toolchain') }}-mathlib-a45ae637-v4
+          key: lean-style-${{ hashFiles('lean-toolchain', 'scripts/vendor-mathlib.sh') }}
           restore-keys: |
-            lean-offline-${{ hashFiles('lean-toolchain') }}-mathlib-a45ae637-v4
+            lean-style-
+            lean-offline-${{ hashFiles('lean-toolchain') }}-mathlib-a45ae637-
+            lean-offline-
 
       - name: Set up Lean (elan)
         run: |
+          set -euo pipefail
           curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
           export PATH="$HOME/.elan/bin:$PATH"
           TOOLCHAIN=$(tr -d '\n\r' < lean-toolchain)
           if ! "$HOME/.elan/bin/elan" toolchain list | grep -Fq "$TOOLCHAIN"; then
-            # ci-honesty: justified wave7-remediation
-            "$HOME/.elan/bin/elan" toolchain install "$TOOLCHAIN" || true
+            "$HOME/.elan/bin/elan" toolchain install "$TOOLCHAIN"
           fi
           "$HOME/.elan/bin/elan" override set "$TOOLCHAIN"
           lean --version
 
       - name: Vendor mathlib and verify checkout
         id: vendor
-        timeout-minutes: 35
+        timeout-minutes: 25
         run: |
           set -euo pipefail
-          MATHLIB_COMMIT="a45ae63747140c1b2cbad9d46f518015c047047a"
+          MATHLIB_COMMIT="${{ env.MATHLIB_COMMIT }}"
+          echo "vendor start $(date -u +%H:%M:%S) commit=$MATHLIB_COMMIT"
           if [ -f vendor/mathlib/lakefile.lean ] && [ -d vendor/mathlib/.git ] \
              && [ -d vendor/mathlib/.lake/build/lib ] \
              && [ -n "$(ls -A vendor/mathlib/.lake/build/lib 2>/dev/null)" ]; then
             ACTUAL=$(git -C vendor/mathlib rev-parse HEAD)
             if [ "$ACTUAL" = "$MATHLIB_COMMIT" ]; then
-              echo "Cached vendored mathlib ready, skipping vendor script"
+              echo "Cached vendored mathlib ready (commit=$ACTUAL), skipping vendor script"
+              echo "cache_hit=true" >> "$GITHUB_OUTPUT"
             else
+              echo "Cached commit mismatch ($ACTUAL); refreshing via vendor script"
               chmod +x scripts/vendor-mathlib.sh
               bash scripts/vendor-mathlib.sh
+              echo "cache_hit=false" >> "$GITHUB_OUTPUT"
             fi
           else
+            echo "Warm cache incomplete; running vendor-mathlib.sh"
             chmod +x scripts/vendor-mathlib.sh
             bash scripts/vendor-mathlib.sh
+            echo "cache_hit=false" >> "$GITHUB_OUTPUT"
           fi
           ACTUAL_COMMIT=$(git -C vendor/mathlib rev-parse HEAD)
           if [ "$ACTUAL_COMMIT" != "$MATHLIB_COMMIT" ]; then
             echo "Mathlib commit mismatch: expected $MATHLIB_COMMIT got $ACTUAL_COMMIT"
             exit 1
           fi
+          echo "vendor complete $(date -u +%H:%M:%S) commit=$ACTUAL_COMMIT"
+          test -d vendor/mathlib/.lake/build/lib
+          test -n "$(ls -A vendor/mathlib/.lake/build/lib)"
 
       - name: Block network access
         run: |
@@ -172,15 +198,50 @@ jobs:
           sudo iptables -A OUTPUT -d ::1 -j ACCEPT
 
       - name: Build Lean proofs (offline)
-        timeout-minutes: 35
+        timeout-minutes: 45
         run: |
-          cd core/lean-libs && lake build
-          cd ../../spec-templates/v1/proofs && lake build
-          cd ../../../bundles/my-agent/proofs && lake build
-          cd ../../test-new-user-agent/proofs && lake build
+          set -euo pipefail
+          echo "offline build start $(date -u +%H:%M:%S)"
+          (cd core/lean-libs && lake build)
+          (cd spec-templates/v1/proofs && lake build)
+          (cd bundles/my-agent/proofs && lake build)
+          (cd bundles/test-new-user-agent/proofs && lake build)
+          echo "offline build complete $(date -u +%H:%M:%S)"
+
+      - name: Confirm network still blocked
+        run: |
+          set -euo pipefail
+          if git ls-remote https://github.com/leanprover-community/mathlib4.git HEAD >/dev/null 2>&1; then
+            echo "Network block failed: git ls-remote succeeded"
+            exit 1
+          fi
+          echo "Network block confirmed (git ls-remote failed as expected)"
 
       - name: Restore network access
         if: always()
         run: |
-          # ci-honesty: justified wave7-remediation
+          # ci-honesty: justified wave8-remediation — cleanup after intentional DROP
           sudo iptables -P OUTPUT ACCEPT || true
+
+      - name: Write offline build report
+        if: success()
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          {
+            echo "lean-offline-full: success"
+            echo "mathlib_commit=${{ env.MATHLIB_COMMIT }}"
+            echo "vendor_cache_hit=${{ steps.vendor.outputs.cache_hit }}"
+            echo "toolchain=$(tr -d '\n\r' < lean-toolchain)"
+            echo "event=${{ github.event_name }}"
+            echo "sha=${{ github.sha }}"
+          } > artifacts/lean-offline-full.txt
+          cat artifacts/lean-offline-full.txt
+
+      - name: Upload offline build report
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lean-offline-full-report
+          path: artifacts/lean-offline-full.txt
+          retention-days: 14

--- a/docs/dev/lean-build.md
+++ b/docs/dev/lean-build.md
@@ -24,7 +24,7 @@ provability-fabric/
 
 - **Location**: `vendor/mathlib/`
 - **Version**: v4.7.0
-- **Commit**: `b5eba595428809e96f3ed113bc7ba776c5f801ac`
+- **Commit**: `a45ae63747140c1b2cbad9d46f518015c047047a` (pinned in `scripts/vendor-mathlib.sh`)
 - **Purpose**: Eliminates network dependencies during build
 
 ### 2. Pinned Lean Version
@@ -118,13 +118,12 @@ When updating to a new mathlib version:
 
 ### GitHub Actions
 
-The `.github/workflows/lean-offline.yaml` workflow:
+The `.github/workflows/lean-offline.yaml` workflow has two jobs:
 
-1. **Blocks network access** using `iptables`
-2. **Verifies vendored mathlib** exists and has correct commit
-3. **Builds all Lean projects** in offline mode
-4. **Tests network blocking** by attempting git fetch
-5. **Generates build report** with results
+1. **`lean-offline-smoke`** (push/PR/schedule) — compiles `Runtime.MicroInterp` without mathlib and runs the scoped sorry scan.
+2. **`lean-offline-full`** (Monday schedule + `workflow_dispatch` with `full=true`) — vendors mathlib, blocks network via `iptables`, builds core/spec/bundle Lean projects offline, and uploads a short report.
+
+Full-job cache paths include `vendor/mathlib/.git` and `.lake`, and the cache key matches `lean-style.yaml` so weekly runs restore a warm vendor tree. Historical tip cancels hung on cold `lake exe cache get` when `.git` was omitted from the cache.
 
 ### Local CI Testing
 

--- a/docs/internal/full-repo-audit-reassessment-2026-07-03.md
+++ b/docs/internal/full-repo-audit-reassessment-2026-07-03.md
@@ -8,11 +8,11 @@ Post-remediation reassessment of findings **F01–F39** after local audit progra
 
 | Scope | Detail |
 |-------|--------|
-| **Code state** | Audit remediation merged; Wave 7 tip `b8b78b94` (2026-07-16; #206 ungates + #207 docs). |
-| **CI on `main`** | Inventory **60 / 60** gated green, exit **0 ×2** (2026-07-16). Do **not** claim literal 67/67. |
-| **Main CI** | Tip CI green [29534141623](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29534141623) on `b8b78b94`. |
+| **Code state** | Wave 8 tip lineage after #215–#217; F33 MicroInterp **0** sorry (2026-07-18). |
+| **CI on `main`** | Inventory **69** gated (Wave 8 re-gates); exit **0** after tip k6 pin (#216) + inventory refresh (#217). Do **not** claim literal 67/67. |
+| **Main CI** | Tip CI green [29534141623](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29534141623) on historical `b8b78b94`; Wave 8 tip `386341a91`. |
 | **Local gates** | All merge-gate commands below passed on working tree (2026-07-03); burn-down gates unchanged. |
-| **60/60 sign-off** | **Claimed** (honest gated set after ungates). Literal 67/67 **not claimed**. |
+| **69/69 sign-off** | **Claimed** for gated set after Wave 8. Literal 67/67 **not claimed**. Live AWS/SaaS + cold-cache offline-full remain dispatch/schedule full paths. |
 
 ---
 
@@ -20,16 +20,16 @@ Post-remediation reassessment of findings **F01–F39** after local audit progra
 
 | Metric | 2026-07-02 reassessment | 2026-07-03 v2 |
 |--------|-------------------------|---------------|
-| Findings DONE | 32 | **38** (F23/F24 closed 2026-07-16) |
-| Findings PARTIAL | 6 | **1** (F33 root Policy + MicroInterp); F23/F24 **DONE** (2026-07-16) |
+| Findings DONE | 32 | **39** (F23/F24 closed 2026-07-16; F33 MicroInterp closed 2026-07-18) |
+| Findings PARTIAL | 6 | **0** |
 | Findings OPEN | 1 (F38) | **0** |
-| Gated workflows green on `main` | 13 / 68 | **5 / 68** post-merge snapshot (43 queued); refresh after wave completes |
+| Gated workflows green on `main` | 13 / 68 | **69** gated after Wave 8 re-gates (#215–#217) |
 | Sidecar production unwrap/expect | 40 | **0** (`--max 10`) |
 | Ledger `any` | 76 | **0** (`--max 20`) |
 | CI honesty unjustified | 59 | **0** (56 justified) |
 | Invariants.lean `sorry` | 7 | **0** |
-| Out-of-scope Lean sorry | 15 | **6** (root Policy + MicroInterp) |
-| CI-enforced Lean targets | 5 paths | **6 paths** (+ `Invariants.lean`, 2026-07-03) |
+| Out-of-scope Lean sorry (F33 set) | 15 | **0** (Policy trees + MicroInterp closed) |
+| CI-enforced Lean targets | 5 paths | **6 paths** (+ `Invariants.lean`, 2026-07-03); MicroInterp scanned by lean-offline smoke |
 
 ---
 
@@ -54,19 +54,17 @@ Post-remediation reassessment of findings **F01–F39** after local audit progra
 
 ## Findings summary
 
-### DONE (38) — including main CI proof
+### DONE (39) — including main CI proof
 
-F01–F32, F34–F39. Trust chain, ledger/MCP, sidecar burn-down, CI honesty, demos, ESLint 9, retention SQL guard, retrieval-gateway, compose profiles, F23 Criterion, F24 paper-conformance. Phase 3 hardening run IDs in Phase D table.
+F01–F39. Trust chain, ledger/MCP, sidecar burn-down, CI honesty, demos, ESLint 9, retention SQL guard, retrieval-gateway, compose profiles, F23 Criterion, F24 paper-conformance, **F33 Lean sorry debt** (Invariants + both Policy trees + MicroInterp **0** sorry; Runtime lake target; lean-style ENFORCED not weakened).
 
-### PARTIAL (1)
+### PARTIAL (0)
 
-| ID | Local | Remaining for DONE |
-|----|-------|-------------------|
-| **F33** | `Invariants.lean` **0 sorry** + **CI-enforced**; `proofs/Policy.lean` **0 sorry** | Consolidate root `Policy.lean` (4 sorry); prove MicroInterp (2) |
+None. F33 closed 2026-07-18 (PR #215): `dfa_semantics_match` proved; see [lean-sorry-burn-down.md](lean-sorry-burn-down.md).
 
-#### F33 — Invariants enforced-set expansion (2026-07-03)
+#### F33 — closed (2026-07-18)
 
-`core/lean-libs/Invariants.lean` is now in the `lean-style.yaml` **ENFORCED** list alongside ActionDSL, Budget, and bundle specs. The workflow step **Check for 'sorry' or 'by admit' in CI-enforced Lean targets** will fail if any placeholder is reintroduced in Invariants. Existing enforced targets were not weakened. See [lean-sorry-burn-down.md](lean-sorry-burn-down.md).
+`core/lean-libs/Invariants.lean` remains in the `lean-style.yaml` **ENFORCED** list. MicroInterp is lake-built and scanned by `lean-offline` smoke; do **not** add it to lean-style ENFORCED until an Extended.Event adapter exists. Existing enforced targets were not weakened.
 
 ### OPEN (0)
 
@@ -95,7 +93,7 @@ F38 ESLint 9 migration complete (root flat config + packages).
 | phase1-platform-lean | **IN PROGRESS** | `integration.yaml` [28585706085](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585706085), `paper-conformance.yaml` [28585705694](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705694) queued |
 | phase1-bench-docs | **IN PROGRESS** | `docs-build.yaml` [28585705338](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705338) queued; Criterion [28585900934](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585900934) queued |
 | phase1-remaining-workflows | **IN PROGRESS** | Inventory **5/68** honest snapshot; refresh after queue drains |
-| phase2-f33-policy | **PARTIAL** | `proofs/Policy.lean` 0 sorry; root `Policy.lean` 4 sorry; `MicroInterp.lean` 2 sorry |
+| phase2-f33-policy | **DONE** | F33 closed 2026-07-18: MicroInterp **0** sorry + Runtime lake; Policy trees **0**; PR #215 |
 | phase3-hardening-proof | **DONE** | F01/F02/F03–F05/F21 proven on `main` with run IDs (Phase D table); tip `b8b78b94` |
 | phase4-signoff | **DONE** | Inventory **60/60** exit 0 ×2; F23/F24 DONE; ungated list recorded; literal 67/67 **not claimed** |
 
@@ -108,7 +106,7 @@ F38 ESLint 9 migration complete (root flat config + packages).
 | phase1-platform-lean | **NOT STARTED (main)** | `Invariants.lean` ENFORCED; `integration` compose smoke fix `05d9cd6a`; re-run [28583016953](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28583016953) queued |
 | phase1-bench-docs | **NOT STARTED (main)** | `Documentation Build` PR green [28582134001](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28582134001); Criterion baseline refresh not dispatched on `main` |
 | phase1-remaining-workflows | **NOT STARTED** | `main` 13/68; inventory refresh deferred until merge |
-| phase2-f33-policy | **PARTIAL** | `proofs/Policy.lean` 0 sorry; root `Policy.lean` 4 sorry; `MicroInterp.lean` 2 sorry |
+| phase2-f33-policy | **DONE** | F33 closed 2026-07-18: MicroInterp **0** sorry + Runtime lake; Policy trees **0**; PR #215 |
 | phase3-hardening-proof | **WIRED ONLY** | F01/F03-F05/F21 in workflows; no `main` CI run IDs |
 | phase4-signoff | **IN PROGRESS** | Docs updated with PR run IDs; 68/68 **not claimed** |
 
@@ -131,7 +129,7 @@ Runbook: [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md). Cluster hel
 
 ## Honest bottom line
 
-**Wave 7 Phase 3+4 complete (2026-07-16).** Tip `b8b78b94`. Inventory **60/60** gated green, exit **0 ×2**. F23/F24 **DONE**. Phase 3 hardening (F01–F05, F21) proven with main run IDs. Seven SaaS/AWS workflows remain honestly ungated (`workflow_dispatch` only). Literal **67/67 is not claimed**. F33 Lean sorry debt remains PARTIAL (root Policy + MicroInterp).
+**Wave 7 Phase 3+4 complete (2026-07-16).** Historical tip `b8b78b94`. Inventory **60/60** gated green, exit **0 ×2**. F23/F24 **DONE**. Phase 3 hardening (F01–F05, F21) proven with main run IDs. **Wave 8 (2026-07-18):** F33 **DONE** (MicroInterp 0 sorry); 8 leftovers re-gated; tip `386341a91`; inventory **69** gated. Live AWS DR / multi-region SaaS / live registry publish / live revocation remain secret-gated or dispatch live modes. `lean-offline-full` is schedule + dispatch (not demoted to smoke-only). Literal **67/67 is not claimed**.
 
 ---
 

--- a/docs/internal/remediation-tracker.md
+++ b/docs/internal/remediation-tracker.md
@@ -134,7 +134,7 @@ Re-run: `scripts/ci_workflow_inventory.sh` (Linux/WSL/Git Bash) or `powershell -
 
 **Wave 7 inventory gate:** **DONE** — inventory exit **0** twice on `main` @ `7d48b3d4` (**60/60** gated green); tip `b8b78b94` after #207. Phase 3+4: [wave7-post-merge-runbook.md](wave7-post-merge-runbook.md).
 
-**Wave 8 revive (2026-07-18):** **PR #215** re-gated leftovers with honest smokes — `art-benchmark`, `lean-offline` (Runtime smoke), `dr-cross` (secret-presence skip), `edge-load` / `loadtest` / `perf-proofmeter` (local mock + tiny k6/bench), `publish-updates` / `revocation-sync` (dry-run). Tip inventory after #215: **69** gated; sole red was `platform-perf-smoke` (k6 `releases/latest` API 403) — fixed by pinning `K6_VERSION=0.47.0`. Full SaaS/AWS / vendored-mathlib offline paths stay dispatch-only. Do **not** claim literal 67/67.
+**Wave 8 revive (2026-07-18):** **PR #215** re-gated leftovers with honest smokes — `art-benchmark`, `lean-offline` (Runtime smoke), `dr-cross` (secret-presence skip), `edge-load` / `loadtest` / `perf-proofmeter` (local mock + tiny k6/bench), `publish-updates` / `revocation-sync` (dry-run). Tip inventory after #215–#217: **69** gated. `lean-offline-full` is schedule + `workflow_dispatch` (`full=true`); cache shares `lean-style` mathlib key/paths (includes `.git`). Live SaaS/AWS stay secret/live-mode only. Do **not** claim literal 67/67.
 
 ---
 

--- a/docs/internal/wave7-post-merge-runbook.md
+++ b/docs/internal/wave7-post-merge-runbook.md
@@ -8,7 +8,22 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 
 ---
 
-## Status (2026-07-18 — Wave 8 revive + tip k6 pin)
+## Status (2026-07-18 — Wave 8 lean-offline-full harden)
+
+**Tip:** `386341a91` (#217 inventory refresh) prior to lean-offline-full harden PR.
+
+| Phase | Status | Evidence |
+|-------|--------|----------|
+| Wave 7 Phase 3+4 | **DONE** | Historical **60/60** @ `b8b78b94` (below) |
+| Wave 8 F33 | **DONE** | MicroInterp `dfa_semantics_match` proved; tracker + reassessment **DONE** |
+| Wave 8 re-gates | **DONE** | `art-benchmark`, `lean-offline` smoke, `dr-cross` secret-skip, `edge-load`/`loadtest`/`perf-proofmeter`, `publish-updates`/`revocation-sync` green on tip |
+| Tip unblock | **DONE** | `platform-perf-smoke` green @ tip after k6 pin ([29638438109](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438109)); inventory exit **0** |
+| lean-offline-full | **IN PROGRESS** | Schedule + dispatch; cache key/paths share `lean-style` (includes `vendor/mathlib/.git`); vendor timeout 25m; job 120m; smoke stays push/PR gate |
+| **Next action** | **Prove full** | Dispatch `full=true` on tip after merge; Monday schedule inherits warm lean-style cache |
+
+**Still deferred (honest; not demoted):** live AWS DR (`dr-cross` with secrets), multi-region SaaS load, live registry publish, live revocation sync. Smoke/dry-run/secret-skip paths stay gated and do not claim live proof. `lean-offline-full` is no longer dispatch-only — it also runs on the Monday schedule.
+
+### Prior status (2026-07-18 — Wave 8 revive + tip k6 pin)
 
 **Merged:** **PR #215** (F33 MicroInterp 0 sorry + re-gate 8 leftover smokes) @ `ad4fafd20`. Inventory after tip: **69 gated**, **1 red** (`platform-perf-smoke` — unauthenticated GitHub API 403 fetching k6 `releases/latest`). Follow-up pins `K6_VERSION=0.47.0` in `platform-perf-smoke.yml` + `slo-gates.yaml`.
 
@@ -18,9 +33,9 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 | Wave 8 F33 | **DONE** | MicroInterp `dfa_semantics_match` proved; lean-style ENFORCED not weakened |
 | Wave 8 re-gates | **DONE** | `art-benchmark`, `lean-offline` smoke, `dr-cross` secret-skip, `edge-load`/`loadtest`/`perf-proofmeter`, `publish-updates`/`revocation-sync` green on tip |
 | Tip unblock | **DONE** | `platform-perf-smoke` green @ tip after k6 pin ([29638438109](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438109)); inventory exit **0** |
-| **Next action** | **Optional** | Full SaaS/AWS + lean-offline-full remain dispatch-only |
+| **Next action** | **Optional** | Full SaaS/AWS remain dispatch/live; lean-offline-full moved to schedule+dispatch |
 
-**Still deferred (honest; not demoted — dispatch/full paths):** live AWS DR (`dr-cross` with secrets), multi-region SaaS load, live registry publish, live revocation sync, vendored-mathlib `lean-offline-full`. Smoke/dry-run/skip paths are gated.
+**Still deferred (honest; not demoted — live/secret paths):** live AWS DR (`dr-cross` with secrets), multi-region SaaS load, live registry publish, live revocation sync. Smoke/dry-run/skip paths are gated.
 
 ### Prior status (2026-07-16 — Wave 7 / Phase 3+4 sign-off)
 

--- a/scripts/vendor-mathlib.sh
+++ b/scripts/vendor-mathlib.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 echo "Vendoring mathlib for offline builds..."
+echo "vendor-mathlib start $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 # Configuration
 MATHLIB_VERSION="v4.7.0"
@@ -79,3 +80,4 @@ echo "Mathlib vendored successfully!"
 echo "Location: $VENDOR_DIR"
 echo "Commit: $MATHLIB_COMMIT"
 echo "Version: $MATHLIB_VERSION"
+echo "vendor-mathlib complete $(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
## Summary - Share \lean-style\ mathlib cache key/paths (include \endor/mathlib/.git\) so weekly \lean-offline-full\ restores a warm vendor tree instead of hanging on cold \lake exe cache get\. - Enable full job on Monday schedule (+ dispatch \ull=true\); smoke stays the push/PR gate; vendor timeout 25m / job 120m; offline network-block check + report artifact. - Mark F33 DONE in reassessment; runbook/tracker note schedule+dispatch (not demoted).  ## Test plan - [ ] PR lean-offline smoke green - [ ] After merge: \gh workflow run lean-offline.yaml -f full=true\ on main - [ ] Vendor step completes (cache hit preferred); offline builds succeed - [ ] Inventory exit 0 on tip (69 gated) 