### PR TITLE
fix(ci): lean-offline-full iptables ::1 block

### DIFF
--- a/.github/workflows/lean-offline.yaml
+++ b/.github/workflows/lean-offline.yaml
@@ -193,9 +193,15 @@ jobs:
 
       - name: Block network access
         run: |
+          set -euo pipefail
+          # IPv4 only via iptables; ::1 must use ip6tables (iptables rejects it).
           sudo iptables -P OUTPUT DROP
+          sudo iptables -A OUTPUT -o lo -j ACCEPT
           sudo iptables -A OUTPUT -d 127.0.0.1 -j ACCEPT
-          sudo iptables -A OUTPUT -d ::1 -j ACCEPT
+          if command -v ip6tables >/dev/null 2>&1; then
+            sudo ip6tables -P OUTPUT DROP
+            sudo ip6tables -A OUTPUT -o lo -j ACCEPT
+          fi
 
       - name: Build Lean proofs (offline)
         timeout-minutes: 45
@@ -222,6 +228,9 @@ jobs:
         run: |
           # ci-honesty: justified wave8-remediation — cleanup after intentional DROP
           sudo iptables -P OUTPUT ACCEPT || true
+          if command -v ip6tables >/dev/null 2>&1; then
+            sudo ip6tables -P OUTPUT ACCEPT || true
+          fi
 
       - name: Write offline build report
         if: success()

--- a/.github/workflows/lean-offline.yaml
+++ b/.github/workflows/lean-offline.yaml
@@ -229,6 +229,7 @@ jobs:
           # ci-honesty: justified wave8-remediation — cleanup after intentional DROP
           sudo iptables -P OUTPUT ACCEPT || true
           if command -v ip6tables >/dev/null 2>&1; then
+            # ci-honesty: justified wave8-remediation — cleanup after intentional DROP
             sudo ip6tables -P OUTPUT ACCEPT || true
           fi
 

--- a/docs/internal/wave7-post-merge-runbook.md
+++ b/docs/internal/wave7-post-merge-runbook.md
@@ -18,7 +18,7 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 | Wave 8 F33 | **DONE** | MicroInterp `dfa_semantics_match` proved; tracker + reassessment **DONE** |
 | Wave 8 re-gates | **DONE** | `art-benchmark`, `lean-offline` smoke, `dr-cross` secret-skip, `edge-load`/`loadtest`/`perf-proofmeter`, `publish-updates`/`revocation-sync` green on tip |
 | Tip unblock | **DONE** | `platform-perf-smoke` green @ tip after k6 pin ([29638438109](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438109)); inventory exit **0** |
-| lean-offline-full | **IN PROGRESS** | Schedule + dispatch; cache key/paths share `lean-style` (includes `vendor/mathlib/.git`); vendor timeout 25m; job 120m; smoke stays push/PR gate |
+| lean-offline-full | **IN PROGRESS** | Vendor step proved on tip ([29645578738](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29645578738) — cache share worked ~1m); offline build blocked on iptables `::1` (IPv4 iptables); follow-up uses `lo` + ip6tables |
 | **Next action** | **Prove full** | Dispatch `full=true` on tip after merge; Monday schedule inherits warm lean-style cache |
 
 **Still deferred (honest; not demoted):** live AWS DR (`dr-cross` with secrets), multi-region SaaS load, live registry publish, live revocation sync. Smoke/dry-run/secret-skip paths stay gated and do not claim live proof. `lean-offline-full` is no longer dispatch-only — it also runs on the Monday schedule.


### PR DESCRIPTION
## Summary
- Vendor step already green with shared lean-style cache on tip.
- Fix offline network block: use `lo` + ip6tables instead of `iptables -d ::1` (IPv4 iptables rejects IPv6).

## Test plan
- [ ] Merge and `gh workflow run lean-offline.yaml -f full=true`
- [ ] Full job: vendor + offline lake build + network confirm green