### PR TITLE
fix(ci): materialize Lake deps before lean-offline DROP

### DIFF
--- a/.github/workflows/lean-offline.yaml
+++ b/.github/workflows/lean-offline.yaml
@@ -191,6 +191,19 @@ jobs:
           test -d vendor/mathlib/.lake/build/lib
           test -n "$(ls -A vendor/mathlib/.lake/build/lib)"
 
+      # Mathlib pulls std (and friends) via Lake; those clones must finish
+      # before iptables DROP or offline `lake build` dies on DNS.
+      - name: Materialize Lake dependencies (online)
+        timeout-minutes: 25
+        run: |
+          set -euo pipefail
+          echo "lake deps start $(date -u +%H:%M:%S)"
+          for d in core/lean-libs spec-templates/v1/proofs bundles/my-agent/proofs bundles/test-new-user-agent/proofs; do
+            echo "lake update → $d"
+            (cd "$d" && lake update)
+          done
+          echo "lake deps complete $(date -u +%H:%M:%S)"
+
       - name: Block network access
         run: |
           set -euo pipefail

--- a/docs/dev/lean-build.md
+++ b/docs/dev/lean-build.md
@@ -121,9 +121,9 @@ When updating to a new mathlib version:
 The `.github/workflows/lean-offline.yaml` workflow has two jobs:
 
 1. **`lean-offline-smoke`** (push/PR/schedule) — compiles `Runtime.MicroInterp` without mathlib and runs the scoped sorry scan.
-2. **`lean-offline-full`** (Monday schedule + `workflow_dispatch` with `full=true`) — vendors mathlib, blocks network via `iptables`, builds core/spec/bundle Lean projects offline, and uploads a short report.
+2. **`lean-offline-full`** (Monday schedule + `workflow_dispatch` with `full=true`) — vendors mathlib, materializes Lake deps online (`lake update`, including std), blocks network via `iptables`/`ip6tables`, builds core/spec/bundle Lean projects offline, and uploads a short report.
 
-Full-job cache paths include `vendor/mathlib/.git` and `.lake`, and the cache key matches `lean-style.yaml` so weekly runs restore a warm vendor tree. Historical tip cancels hung on cold `lake exe cache get` when `.git` was omitted from the cache.
+Full-job cache paths include `vendor/mathlib/.git` and `.lake`, and the cache key matches `lean-style.yaml` so weekly runs restore a warm vendor tree. Historical tip cancels hung on cold `lake exe cache get` when `.git` was omitted from the cache. Offline builds require the Lake package graph (e.g. std) to be materialized before the network block.
 
 ### Local CI Testing
 

--- a/docs/internal/wave7-post-merge-runbook.md
+++ b/docs/internal/wave7-post-merge-runbook.md
@@ -18,7 +18,7 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 | Wave 8 F33 | **DONE** | MicroInterp `dfa_semantics_match` proved; tracker + reassessment **DONE** |
 | Wave 8 re-gates | **DONE** | `art-benchmark`, `lean-offline` smoke, `dr-cross` secret-skip, `edge-load`/`loadtest`/`perf-proofmeter`, `publish-updates`/`revocation-sync` green on tip |
 | Tip unblock | **DONE** | `platform-perf-smoke` green @ tip after k6 pin ([29638438109](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438109)); inventory exit **0** |
-| lean-offline-full | **IN PROGRESS** | Vendor step proved on tip ([29645578738](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29645578738) — cache share worked ~1m); offline build blocked on iptables `::1` (IPv4 iptables); follow-up uses `lo` + ip6tables |
+| lean-offline-full | **IN PROGRESS** | Vendor + iptables proved; offline build needs online `lake update` first (std clone). Materialize-deps step in follow-up |
 | **Next action** | **Prove full** | Dispatch `full=true` on tip after merge; Monday schedule inherits warm lean-style cache |
 
 **Still deferred (honest; not demoted):** live AWS DR (`dr-cross` with secrets), multi-region SaaS load, live registry publish, live revocation sync. Smoke/dry-run/secret-skip paths stay gated and do not claim live proof. `lean-offline-full` is no longer dispatch-only — it also runs on the Monday schedule.


### PR DESCRIPTION
## Summary
- Vendor + iptables already green on tip.
- Offline `lake build` failed cloning `std4` after network DROP.
- Add online `lake update` in all Lean project dirs before blocking the network.

## Test plan
- [ ] Merge and dispatch `full=true`
- [ ] Full job green end-to-end