### PR TITLE
docs(internal): sign off CI-local proofs at tip

### DIFF
--- a/docs/internal/ci-inventory-latest.md
+++ b/docs/internal/ci-inventory-latest.md
@@ -1,6 +1,6 @@
 ﻿# CI workflow inventory (auto-generated)
 
-Generated: 2026-07-18T09:55:28Z UTC
+Generated: 2026-07-18T22:04:21Z UTC
 Repository: `SentinelOps-CI/provability-fabric` branch `main`
 
 ## Summary
@@ -17,33 +17,33 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 
 | Workflow | Triggers | Last status | Gated | URL |
 |----------|----------|-------------|-------|-----|
-| `actionlint.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438087 |
+| `actionlint.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142408 |
 | `adapters-ci.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29477314927 |
 | `allowlist-sync.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293487 |
 | `art-benchmark.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293489 |
 | `bench-nightly-criterion.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29631230088 |
 | `bench-swebench-smoke.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29636250075 |
 | `bench-swebench-stress-scheduled.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29522474048 |
-| `bench-swebench-unit.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29525017320 |
+| `bench-swebench-unit.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142435 |
 | `billing-test.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29631314353 |
 | `bundle-check.yaml` | pull_request | no_run | no | - |
 | `cargo-deny.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28631247789 |
 | `cert-validate.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279849 |
 | `chaos-nightly.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29631146379 |
-| `ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438194 |
+| `ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142545 |
 | `ci-nightly-pytest.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29635149380 |
 | `ci-weekly-full.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29515858240 |
 | `cla-bot.yaml` | pull_request, workflow_dispatch | success | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620729102 |
-| `codeql.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438090 |
+| `codeql.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142420 |
 | `compliance.yaml` | release, workflow_dispatch | no_run | no | - |
 | `demo-e2e.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404745 |
 | `dependency-review.yml` | pull_request | no_run | no | - |
 | `dep-graph.yaml` | pull_request | no_run | no | - |
 | `dfa.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647153 |
-| `docs-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438078 |
-| `docs-deploy.yaml` | push | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438099 |
-| `dr-cross.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293492 |
-| `edge-load.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293497 |
+| `docs-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142423 |
+| `docs-deploy.yaml` | push | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142437 |
+| `dr-cross.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142443 |
+| `edge-load.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142462 |
 | `egress.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279890 |
 | `evidence.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29631249737 |
 | `evidence-v01-smoke.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404721 |
@@ -51,29 +51,29 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | `heartbeat-test.yaml` | pull_request, workflow_dispatch | no_run | no | - |
 | `incident-e2e.yaml` | workflow_dispatch | no_run | no | - |
 | `incident-test.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29631105465 |
-| `integration.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29508973757 |
+| `integration.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142448 |
 | `jwks-validate.yml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705444 |
 | `lean-morph.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293494 |
-| `lean-offline.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293513 |
+| `lean-offline.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29646806851 |
 | `lean-style.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293499 |
-| `loadtest.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293488 |
+| `loadtest.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142440 |
 | `marketplace-e2e.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585705631 |
 | `morph-replay.yml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29470279955 |
-| `multiarch-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438094 |
+| `multiarch-build.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142426 |
 | `nightly-replay.yml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29631056221 |
 | `opa-test.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29489277608 |
-| `operational-excellence.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438091 |
+| `operational-excellence.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142410 |
 | `paper-conformance.yaml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293533 |
 | `pcs-ci.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29477314965 |
 | `perf.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29631286401 |
 | `performance-gate.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29513118372 |
-| `perf-proofmeter.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293512 |
+| `perf-proofmeter.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142429 |
 | `pf-ci.yaml` | workflow_dispatch, workflow_call | success | no | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620728032 |
-| `pf-core-schema-check.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438068 |
+| `pf-core-schema-check.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142454 |
 | `pf-cross-repo-consumer.yaml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29620719836 |
 | `pf-reusable-caller.yaml` | pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29633154940 |
 | `platform-cert-validate.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29630836767 |
-| `platform-perf-smoke.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438109 |
+| `platform-perf-smoke.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142417 |
 | `platform-replay.yml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632334019 |
 | `policy-build.yml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/28585647162 |
 | `policy-gates.yaml` | push, pull_request | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293506 |
@@ -83,7 +83,7 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | `proof-bot.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29631013102 |
 | `proof-fuzz.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293518 |
 | `proto-compat.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29630750024 |
-| `publish-updates.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293482 |
+| `publish-updates.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142449 |
 | `rbac-test.yaml` | pull_request, workflow_dispatch | no_run | no | - |
 | `redteam.yaml` | pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29520388261 |
 | `release.yaml` | push, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29528283470 |
@@ -95,10 +95,10 @@ Repository: `SentinelOps-CI/provability-fabric` branch `main`
 | `reusable-ci-lean.yml` | workflow_call | no_run | no | - |
 | `reusable-ci-prepare.yml` | workflow_call | no_run | no | - |
 | `reusable-ci-rust.yml` | workflow_call | no_run | no | - |
-| `revocation-sync.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29632293490 |
-| `sbom-diff.yaml` | push, pull_request, release | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438076 |
-| `scorecards.yml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438083 |
-| `slo-gates.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29638438070 |
+| `revocation-sync.yaml` | push, pull_request, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142430 |
+| `sbom-diff.yaml` | push, pull_request, release | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142422 |
+| `scorecards.yml` | push, schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142424 |
+| `slo-gates.yaml` | push, pull_request, schedule | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142428 |
 | `spec-ai.yaml` | pull_request | no_run | no | - |
 | `standards-pin.yml` | push, pull_request, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29465404740 |
 | `trust-fire-ga-test.yaml` | schedule, workflow_dispatch | success | yes | https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29522471801 |

--- a/docs/internal/remediation-tracker.md
+++ b/docs/internal/remediation-tracker.md
@@ -20,7 +20,7 @@ Captured via `powershell -File scripts/ci_workflow_inventory.ps1 -Markdown` (202
 | Latest run **failure / cancelled** (ungated / PR-only) | 0 |
 | No run / unknown | 16 |
 
-**Green snapshot (tip `3f71ea97`, 2026-07-18):** inventory exit **0** — **69** gated (push/schedule) prior to CI-local-proofs PR; Wave 7 historical **60/60** @ `b8b78b94` remains the pre-revive baseline. Do **not** claim literal 67/67.
+**Green snapshot (tip `bae36f642`, 2026-07-18):** inventory exit **0 ×2** — **69** gated (push/schedule), **0** red after **PR #223** CI-local proofs. Wave 7 historical **60/60** @ `b8b78b94` remains the pre-revive baseline. Do **not** claim literal 67/67.
 
 **No run on main (gated):** none — full gated set green.
 

--- a/docs/internal/wave7-post-merge-runbook.md
+++ b/docs/internal/wave7-post-merge-runbook.md
@@ -8,9 +8,9 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 
 ---
 
-## Status (2026-07-18 — CI-local proofs for deferred leftovers)
+## Status (2026-07-18 — CI-local proofs merged @ `bae36f642`)
 
-**Prior tip:** `3f71ea97` (#222 docs sign-off). This wave replaces secret-absent empty skips with real CI-local proofs (moto DR, mock-registry sync/sign, packaged publish dry-run, multi-region k6 asserts).
+**Tip:** `bae36f642` (**PR #223**). Inventory exit **0 ×2** — **69** gated / **0** red. Replaces secret-absent empty skips with real CI-local proofs (moto DR, mock-registry sync/sign, packaged publish dry-run, multi-region k6 asserts).
 
 | Phase | Status | Evidence |
 |-------|--------|----------|
@@ -18,15 +18,18 @@ Inventory baseline: [ci-inventory-latest.md](ci-inventory-latest.md). Cluster ma
 | Wave 8 F33 | **DONE** | MicroInterp `dfa_semantics_match` proved; tracker + reassessment **DONE** |
 | Wave 8 re-gates | **DONE** | Prior smokes @ #215–#217 |
 | lean-offline-full | **DONE** | [29646806851](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29646806851) |
-| CI-local DR (`dr-cross`) | **DONE (CI)** | moto S3 CRR + Route53 failover flip + `blue_green_migrate.sh --dry-run` when AWS secrets absent |
-| publish-updates dry-run | **DONE (CI)** | fixture metrics → tar.gz package + HMAC sign + mock-registry publish |
-| revocation-sync dry-run | **DONE (CI)** | mock HTTP registry merge + package/sign assertions |
-| edge-load / loadtest / perf-proofmeter | **DONE (CI)** | local mock stack + k6/bench latency & error-rate asserts; multi-region edge smoke on :8081–8083 |
+| CI-local DR (`dr-cross`) | **DONE (CI)** | Tip green [29661142443](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142443) — moto S3 CRR + Route53 failover + `blue_green_migrate.sh --dry-run` |
+| publish-updates dry-run | **DONE (CI)** | Tip green [29661142449](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142449) — package + HMAC + mock-registry |
+| revocation-sync dry-run | **DONE (CI)** | Tip green [29661142430](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142430) — mock registry merge/sign |
+| edge-load / loadtest / perf-proofmeter | **DONE (CI)** | Tip green [29661142462](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142462) / [29661142440](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142440) / [29661142429](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29661142429) |
+| Inventory ceremony | **DONE** | Exit **0 ×2** @ `bae36f642` — **69** gated / **0** red |
 | **Next action** | **Optional live** | Production AWS DR, live multi-region SaaS, live registry publish, live revocation sync |
 
 **CI-proven (local/mock; gated):** cross-region DR scripts/terraform surface via moto; publish packaging/signing; revocation sync logic; CI-sized load profiles with hard asserts.
 
 **Still needs live secrets / production endpoints (honest; not demoted):** live AWS RDS/Route53/S3 DR, live multi-region SaaS edge load (`edge-load` mode=full), live registry publish (`publish-updates` dry_run=false), live external revocation fetch (`revocation-sync` mode=live).
+
+**Dependabot:** deferred (non-trivial Rust/JS bumps and conflict-prone PRs; #152 tiny but red checks).
 
 ### Prior status (2026-07-18 — Final Wave 7 verification)
 

--- a/docs/roadmap/evidence-program-closure.md
+++ b/docs/roadmap/evidence-program-closure.md
@@ -22,9 +22,9 @@ scripts/ci_workflow_inventory.sh --markdown   # docs/internal/ci-inventory-lates
 # Windows: scripts/ci_workflow_inventory.ps1 -Markdown
 ```
 
-**Current posture (2026-07-18 — CI-local proofs for deferred leftovers):** Prior tip `3f71ea97` (#222). F33 **DONE**; `lean-offline-full` proven ([29646806851](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29646806851)). Previously skip-only paths now have gated CI-local proofs: `dr-cross` (moto S3/Route53 + blue/green dry-run), `publish-updates` (package+HMAC+mock registry), `revocation-sync` (mock registry merge/sign), `edge-load`/`loadtest`/`perf-proofmeter` (latency/error asserts + multi-region mock). Still live-secret only: production AWS DR, live multi-region SaaS, live registry publish, live revocation fetch. Do **not** claim literal 67/67. Runbook: [wave7-post-merge-runbook.md](../internal/wave7-post-merge-runbook.md); [ci-inventory-latest.md](../internal/ci-inventory-latest.md).
+**Current posture (2026-07-18 — CI-local proofs @ `bae36f642`):** **PR #223** merged. F33 **DONE**; `lean-offline-full` proven ([29646806851](https://github.com/SentinelOps-CI/provability-fabric/actions/runs/29646806851)). Gated CI-local proofs: `dr-cross` (moto), `publish-updates` (package+HMAC+mock registry), `revocation-sync` (mock registry merge/sign), `edge-load`/`loadtest`/`perf-proofmeter` (latency/error asserts + multi-region mock). Inventory exit **0 ×2** — **69** gated. Still live-secret only: production AWS DR, live multi-region SaaS, live registry publish, live revocation fetch. Do **not** claim literal 67/67. Runbook: [wave7-post-merge-runbook.md](../internal/wave7-post-merge-runbook.md); [ci-inventory-latest.md](../internal/ci-inventory-latest.md).
 
-**Inventory exit 0 claimed** at **69** gated (tip `3f71ea97` pre-proofs). Wave 7 historical **60/60** first closed @ `7d48b3d4` / tip `b8b78b94`.
+**Inventory exit 0 ×2 claimed** at **69** gated (tip `bae36f642`). Wave 7 historical **60/60** first closed @ `7d48b3d4` / tip `b8b78b94`.
 
 ### Path to 67/67 (Wave 7 — closed 2026-07-16)
 


### PR DESCRIPTION
## Summary
- Record tip `bae36f642` (#223) inventory exit 0 x2 (69 gated)
- Cite tip-green run IDs for moto DR, publish/revocation dry-runs, load smokes
- Note Dependabot deferred

## Test plan
- [x] Inventory exit 0 x2 already observed on tip