### PR TITLE
chore(deps): update pymdown-extensions requirement to >=11.0.1 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # MkDocs stack for CI and local builds (see root mkdocs.yml, docs_dir: docs).
 mkdocs-material>=9.5,<10
 mkdocs-mermaid2-plugin>=1.1.0
-pymdown-extensions>=11.0
+pymdown-extensions>=11.0.1


### PR DESCRIPTION
## Summary
- Recreate Dependabot #152 (pymdown-extensions>=11.0 -> >=11.0.1) on a maintainer branch from tip main so Documentation Build can use `STANDARDS_GITHUB_TOKEN` for `make submodules`.
- Same one-line docs requirement bump as #152; closes the Dependabot PR once this lands.

## Test plan
- [ ] Documentation Build green
- [ ] CI required checks green
- [ ] After merge, close #152 as superseded